### PR TITLE
Export device type metadata from include path

### DIFF
--- a/calibration/metadata.py
+++ b/calibration/metadata.py
@@ -39,11 +39,13 @@ def list_metadata(elements, **kwargs):
             nodes = x.xpath('./x:Workflow/x:Nodes', namespaces=ns)[0]
             metadata[name] = list_metadata(nodes)
         elif grouptype != "ExternalizedMapping":
-            elem_metadata = {}
-            elem_metadata = (recursive_dict(x)[1])
+            elem_metadata = recursive_dict(x)[1]
             if elem_metadata is None:
                 continue
             elem_metadata.update(kwargs)
+            if grouptype == "IncludeWorkflow":
+                path = Path(x.get('Path')).stem
+                elem_metadata['Type'] = path.rsplit(':', 1)[-1]
             metadata |= elem_metadata
     return metadata
 


### PR DESCRIPTION
Reusable devices are always encapsulated in workflow modules and their paths can be used to uniquely identify the device "type". This PR ensures a device type attribute is exported by looking up the included device workflow module path and extracting the path stem.

In the future the qualifying assembly prefix could be retained if we ever require the ID to include the name of the package.

Fixes #213 