### PR TITLE
Add documentation on configuring CEPH and webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,17 @@ In case the configuration of the environment ever gets corrupted, you can revert
 
 Data is continuously transferred to a CEPH partition by calling Robocopy from a scheduled task which runs periodically every hour. This task is started as soon as the computer boots, using the OS task scheduler. Script with the task definitions for each experiment are versioned in this repository at `workflows\**\RobocopyAeon.xml`. These scripts can be installed in a new computer by opening the Task Scheduler app and selecting `Action > Import Task`.
 
-For example, the data transfer script for Experiment 0.1 currently assumes data is collected in `D:\ProjectAeon\experiment0.1` and backed up to a network mount at `Z:\experiment0.1`.
+The raw data folder name in CEPH should be the Host Name corresponding to the acquisition machine as specified in the table above. Each acquisition computer should be assigned a unique user name with exclusive write permissions over the CEPH folder to which it is writing. Care should be taken to ensure that all other users only have read permissions over the folder. The current recommended naming convention for users is `aeon_<machine_name>` all lowercase.
+
+The remote CEPH folder can be subsequently mounted on the local machine as a network drive and accessed as part of the file system. For example, the data transfer script for Experiment 0.1 running on AEON2 currently assumes data is collected in `D:\ProjectAeon\experiment0.1` and backed up to a network mount at `Z:\experiment0.1` which corresponds to CEPH partition `/aeon/data/raw/AEON2/experiment0.1/`.
+
+### Incoming Webhooks
+
+Alerts in Project Aeon are automatically forwarded to researchers and team members using the [Incoming Webhooks](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/what-are-webhooks-and-connectors#incoming-webhooks) functionality in Microsoft Teams. Incoming Webhooks can be enabled on specific channels on Teams and essentially consist of exposed HTTPS endpoints which will accept and post to the channel any message formatted as a JSON payload complying with the [connector card schema for O365 Groups](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/cards/cards-reference#connector-card-for-microsoft-365-groups). Posting a message simply requires sending a POST command to the HTTPS endpoint exposed by the Incoming Webhook.
+
+Incoming Webhooks can be created directly using the [Teams user interface](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook?tabs=dotnet#create-an-incoming-webhook-1). Each acquisition computer currently has two configured webhooks, one for Alert messages and another for Status messages. Note that only channel admins in Teams are allowed to create and manage Incoming Webhooks.
+
+HTTPS endpoints for each specific machine name are stored in the `config` folder in CEPH, in the `alerts.config` and `status.config` files respectively. CEPH permissions are required to update these files.
 
 ### Calibration Targets
 


### PR DESCRIPTION
This PR adds documentation on how to correctly configure the CEPH partitions and Incoming Webhooks on Teams for the alert system. Where possible we have reused Microsoft's documentation on configuring connectors in the Teams user interface.

Fixes #221 