### PR TITLE
Disable display of progress bar for each file copy

### DIFF
--- a/calibration/robocopy.py
+++ b/calibration/robocopy.py
@@ -11,7 +11,7 @@ args = parser.parse_args()
 source = Path(args.source)
 destination = Path(args.destination)
 dataset = Path(os.getcwd()).name
-robocopy_parameters = ["/E", "/MOVE", "/J", "/R:2", "/W:30"]
+robocopy_parameters = ["/E", "/MOVE", "/J", "/R:2", "/W:30", "/NP"]
 process = subprocess.run(
     ["robocopy", source.joinpath(dataset), destination.joinpath(dataset)] + robocopy_parameters,
     shell=True)


### PR DESCRIPTION
This PR disables the display of the progress bar for each individual file copy operation to avoid cluttering the output with meaningless lines when launching the script programmatically.

Fixes #227 