### PR TITLE
Ensure libgit binaries are copied after restore

### DIFF
--- a/bonsai/setup.ps1
+++ b/bonsai/setup.ps1
@@ -5,8 +5,8 @@ if (!(Test-Path "./Bonsai.exe")) {
     Move-Item -Path "temp.config" "NuGet.config" -Force
     Remove-Item -Path "temp.zip"
     Remove-Item -Path "Bonsai32.exe"
-    Get-ChildItem -Path "Packages" -Recurse -Filter *git2-*.dll |
-        Where-Object FullName -NotLike "*win-x86*" |
-        Copy-Item -Destination "." -Force
 }
 & .\Bonsai.exe --no-editor
+Get-ChildItem -Path "Packages" -Recurse -Filter *git2-*.dll |
+    Where-Object FullName -NotLike "*win-x86*" |
+    Copy-Item -Destination "." -Force


### PR DESCRIPTION
Make sure that the search and copy for libgit binaries is performed only after restore of the environment, otherwise there might not be a binary anywhere to be found.

Fixes #283 