### PR TITLE
Avoid inferring sub-folders in robocopy script

### DIFF
--- a/calibration/robocopy.py
+++ b/calibration/robocopy.py
@@ -10,9 +10,8 @@ parser.add_argument('destination', type=str, help="The remote path where data is
 args = parser.parse_args()
 source = Path(args.source)
 destination = Path(args.destination)
-dataset = Path(os.getcwd()).name
 robocopy_parameters = ["/E", "/MOVE", "/J", "/R:2", "/W:30", "/NP"]
 process = subprocess.run(
-    ["robocopy", source.joinpath(dataset), destination.joinpath(dataset)] + robocopy_parameters,
+    ["robocopy", source, destination] + robocopy_parameters,
     shell=True)
 sys.exit(process.returncode)


### PR DESCRIPTION
This PR avoids appending the current working directory as a sub-folder in the robocopy script, which is incompatible with the current tag-based generation of copy folders and complicates versioning of future startup schemes.

The script itself should always operate with absolute unmodified paths. If modification is needed, this should be specified at the calling site.

Fixes #285 