### PR TITLE
Update bootstrapper to avoid manual copy of DLL

### DIFF
--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -3,7 +3,7 @@
   <Packages>
     <Package id="Aeon.Acquisition" version="0.4.0-build230821" />
     <Package id="AsyncIO" version="0.1.69" />
-    <Package id="Bonsai" version="2.8.0" />
+    <Package id="Bonsai" version="2.8.1" />
     <Package id="Bonsai.Audio" version="2.8.0" />
     <Package id="Bonsai.Core" version="2.8.1" />
     <Package id="Bonsai.Design" version="2.8.0" />
@@ -20,7 +20,7 @@
     <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
     <Package id="Bonsai.Sleap" version="0.2.0" />
     <Package id="Bonsai.Spinnaker" version="0.7.1" />
-    <Package id="Bonsai.System" version="2.8.0" />
+    <Package id="Bonsai.System" version="2.8.1" />
     <Package id="Bonsai.System.Design" version="2.8.0" />
     <Package id="Bonsai.Vision" version="2.8.0" />
     <Package id="Bonsai.Vision.Design" version="2.8.0" />
@@ -93,6 +93,7 @@
     <AssemblyLocation assemblyName="AsyncIO" processorArchitecture="MSIL" location="Packages\AsyncIO.0.1.69\lib\net40\AsyncIO.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="X86" location="Packages\Bonsai.Pylon.0.3.0\build\net462\bin\x86\Basler.Pylon.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="Amd64" location="Packages\Bonsai.Pylon.0.3.0\build\net462\bin\x64\Basler.Pylon.dll" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.1\lib\net48\Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Audio" processorArchitecture="MSIL" location="Packages\Bonsai.Audio.2.8.0\lib\net462\Bonsai.Audio.dll" />
     <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.1\lib\net462\Bonsai.Core.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll" />
@@ -112,7 +113,7 @@
     <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.Design.2.8.0\lib\net462\Bonsai.Scripting.IronPython.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Sleap" processorArchitecture="MSIL" location="Packages\Bonsai.Sleap.0.2.0\lib\net472\Bonsai.Sleap.dll" />
     <AssemblyLocation assemblyName="Bonsai.Spinnaker" processorArchitecture="MSIL" location="Packages\Bonsai.Spinnaker.0.7.1\lib\net462\Bonsai.Spinnaker.dll" />
-    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.0\lib\net462\Bonsai.System.dll" />
+    <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.1\lib\net462\Bonsai.System.dll" />
     <AssemblyLocation assemblyName="Bonsai.System.Design" processorArchitecture="MSIL" location="Packages\Bonsai.System.Design.2.8.0\lib\net462\Bonsai.System.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.2.8.0\lib\net462\Bonsai.Vision.dll" />
     <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.Design.2.8.0\lib\net462\Bonsai.Vision.Design.dll" />

--- a/bonsai/setup.ps1
+++ b/bonsai/setup.ps1
@@ -17,6 +17,3 @@ if (!(Test-Path "./Bonsai.exe")) {
     Remove-Item -Path "Bonsai32.exe"
 }
 & .\Bonsai.exe --no-editor
-Get-ChildItem -Path "Packages" -Recurse -Filter *git2-*.dll |
-    Where-Object FullName -NotLike "*win-x86*" |
-    Copy-Item -Destination "." -Force


### PR DESCRIPTION
This PR updates the Bonsai bootstrapper to the new version 2.8.1 which fixes the issue with scanning of native DLLs that was breaking loading of LibGit2Sharp (https://github.com/bonsai-rx/bonsai/pull/1555). With this fix we should no longer require manually copying the DLL in the setup script.