### PR TITLE
Update foraging package for new dispenser UI

### DIFF
--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -4,7 +4,7 @@
     <Package id="Aeon.Acquisition" version="0.5.0-build231008" />
     <Package id="Aeon.Database" version="0.1.0-build230919" />
     <Package id="Aeon.Environment" version="0.1.0-build231008" />
-    <Package id="Aeon.Foraging" version="0.1.0-build231009" />
+    <Package id="Aeon.Foraging" version="0.1.0-build231010" />
     <Package id="AsyncIO" version="0.1.69" />
     <Package id="Bonsai" version="2.8.1" />
     <Package id="Bonsai.Audio" version="2.8.0" />
@@ -105,7 +105,7 @@
     <AssemblyLocation assemblyName="Aeon.Acquisition" processorArchitecture="MSIL" location="Packages\Aeon.Acquisition.0.5.0-build231008\lib\net472\Aeon.Acquisition.dll" />
     <AssemblyLocation assemblyName="Aeon.Database" processorArchitecture="MSIL" location="Packages\Aeon.Database.0.1.0-build230919\lib\net472\Aeon.Database.dll" />
     <AssemblyLocation assemblyName="Aeon.Environment" processorArchitecture="MSIL" location="Packages\Aeon.Environment.0.1.0-build231008\lib\net472\Aeon.Environment.dll" />
-    <AssemblyLocation assemblyName="Aeon.Foraging" processorArchitecture="MSIL" location="Packages\Aeon.Foraging.0.1.0-build231009\lib\net472\Aeon.Foraging.dll" />
+    <AssemblyLocation assemblyName="Aeon.Foraging" processorArchitecture="MSIL" location="Packages\Aeon.Foraging.0.1.0-build231010\lib\net472\Aeon.Foraging.dll" />
     <AssemblyLocation assemblyName="AsyncIO" processorArchitecture="MSIL" location="Packages\AsyncIO.0.1.69\lib\net40\AsyncIO.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="X86" location="Packages\Bonsai.Pylon.0.3.0\build\net462\bin\x86\Basler.Pylon.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="Amd64" location="Packages\Bonsai.Pylon.0.3.0\build\net462\bin\x64\Basler.Pylon.dll" />


### PR DESCRIPTION
This updates the foraging package to use the new dispenser UI described in https://github.com/SainsburyWellcomeCentre/aeon_acquisition/pull/161.

The proposed separation is a breaking change with old workflows with the goal of making it easier to scale to arbitrary numbers of patches and more complex patch or dispenser states in the future.