### PR TITLE
Add tensorflow runtime packages to improve reproducible deployment

### DIFF
--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -22,6 +22,7 @@
     <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
     <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
     <Package id="Bonsai.Sleap" version="0.2.0" />
+    <Package id="Bonsai.Sleap.Design" version="0.2.0" />
     <Package id="Bonsai.Spinnaker" version="0.7.1" />
     <Package id="Bonsai.System" version="2.8.1" />
     <Package id="Bonsai.System.Design" version="2.8.0" />
@@ -90,6 +91,7 @@
     <AssemblyReference assemblyName="Bonsai.Scripting.IronPython" />
     <AssemblyReference assemblyName="Bonsai.Scripting.IronPython.Design" />
     <AssemblyReference assemblyName="Bonsai.Sleap" />
+    <AssemblyReference assemblyName="Bonsai.Sleap.Design" />
     <AssemblyReference assemblyName="Bonsai.Spinnaker" />
     <AssemblyReference assemblyName="Bonsai.System" />
     <AssemblyReference assemblyName="Bonsai.System.Design" />
@@ -130,6 +132,7 @@
     <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.2.8.0\lib\net462\Bonsai.Scripting.IronPython.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.Design.2.8.0\lib\net462\Bonsai.Scripting.IronPython.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Sleap" processorArchitecture="MSIL" location="Packages\Bonsai.Sleap.0.2.0\lib\net472\Bonsai.Sleap.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Sleap.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Sleap.Design.0.2.0\lib\net472\Bonsai.Sleap.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Spinnaker" processorArchitecture="MSIL" location="Packages\Bonsai.Spinnaker.0.7.1\lib\net462\Bonsai.Spinnaker.dll" />
     <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.1\lib\net462\Bonsai.System.dll" />
     <AssemblyLocation assemblyName="Bonsai.System.Design" processorArchitecture="MSIL" location="Packages\Bonsai.System.Design.2.8.0\lib\net462\Bonsai.System.Design.dll" />


### PR DESCRIPTION
This PR adds references to custom NuGet packages which we have prepared about a year ago to improve the distribution experience of cuDNN and tensorflow runtimes. Unfortunately these packages cannot be uploaded to nuget.org just yet since they exceed the maximum limit of 250 MB (see also https://github.com/NuGet/NuGetGallery/issues/9473).

For now we have pushed these to the CEPH packages folder so they should be picked up by the experimental environments.