### PR TITLE
Update lightcycle operator dependencies

### DIFF
--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -3,7 +3,7 @@
   <Packages>
     <Package id="Aeon.Acquisition" version="0.5.0-build231012" />
     <Package id="Aeon.Database" version="0.1.0-build230919" />
-    <Package id="Aeon.Environment" version="0.1.0-build231013" />
+    <Package id="Aeon.Environment" version="0.1.0-build231014" />
     <Package id="Aeon.Foraging" version="0.1.0-build231011" />
     <Package id="AsyncIO" version="0.1.69" />
     <Package id="Bonsai" version="2.8.1" />
@@ -108,7 +108,7 @@
   <AssemblyLocations>
     <AssemblyLocation assemblyName="Aeon.Acquisition" processorArchitecture="MSIL" location="Packages\Aeon.Acquisition.0.5.0-build231012\lib\net472\Aeon.Acquisition.dll" />
     <AssemblyLocation assemblyName="Aeon.Database" processorArchitecture="MSIL" location="Packages\Aeon.Database.0.1.0-build230919\lib\net472\Aeon.Database.dll" />
-    <AssemblyLocation assemblyName="Aeon.Environment" processorArchitecture="MSIL" location="Packages\Aeon.Environment.0.1.0-build231013\lib\net472\Aeon.Environment.dll" />
+    <AssemblyLocation assemblyName="Aeon.Environment" processorArchitecture="MSIL" location="Packages\Aeon.Environment.0.1.0-build231014\lib\net472\Aeon.Environment.dll" />
     <AssemblyLocation assemblyName="Aeon.Foraging" processorArchitecture="MSIL" location="Packages\Aeon.Foraging.0.1.0-build231011\lib\net472\Aeon.Foraging.dll" />
     <AssemblyLocation assemblyName="AsyncIO" processorArchitecture="MSIL" location="Packages\AsyncIO.0.1.69\lib\net40\AsyncIO.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="X86" location="Packages\Bonsai.Pylon.0.3.0\build\net462\bin\x86\Basler.Pylon.dll" />


### PR DESCRIPTION
This PR updates the environment package to ensure lights are updated only once a minute as described in https://github.com/SainsburyWellcomeCentre/aeon_acquisition/pull/182.