### PR TITLE
Update environment and database dependencies

### DIFF
--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -2,8 +2,8 @@
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
     <Package id="Aeon.Acquisition" version="0.5.0-build231012" />
-    <Package id="Aeon.Database" version="0.1.0-build230919" />
-    <Package id="Aeon.Environment" version="0.1.0-build231014" />
+    <Package id="Aeon.Database" version="0.1.0-build231020" />
+    <Package id="Aeon.Environment" version="0.1.0-build231015" />
     <Package id="Aeon.Foraging" version="0.1.0-build231011" />
     <Package id="AsyncIO" version="0.1.69" />
     <Package id="Bonsai" version="2.8.1" />
@@ -107,8 +107,8 @@
   </AssemblyReferences>
   <AssemblyLocations>
     <AssemblyLocation assemblyName="Aeon.Acquisition" processorArchitecture="MSIL" location="Packages\Aeon.Acquisition.0.5.0-build231012\lib\net472\Aeon.Acquisition.dll" />
-    <AssemblyLocation assemblyName="Aeon.Database" processorArchitecture="MSIL" location="Packages\Aeon.Database.0.1.0-build230919\lib\net472\Aeon.Database.dll" />
-    <AssemblyLocation assemblyName="Aeon.Environment" processorArchitecture="MSIL" location="Packages\Aeon.Environment.0.1.0-build231014\lib\net472\Aeon.Environment.dll" />
+    <AssemblyLocation assemblyName="Aeon.Database" processorArchitecture="MSIL" location="Packages\Aeon.Database.0.1.0-build231020\lib\net472\Aeon.Database.dll" />
+    <AssemblyLocation assemblyName="Aeon.Environment" processorArchitecture="MSIL" location="Packages\Aeon.Environment.0.1.0-build231015\lib\net472\Aeon.Environment.dll" />
     <AssemblyLocation assemblyName="Aeon.Foraging" processorArchitecture="MSIL" location="Packages\Aeon.Foraging.0.1.0-build231011\lib\net472\Aeon.Foraging.dll" />
     <AssemblyLocation assemblyName="AsyncIO" processorArchitecture="MSIL" location="Packages\AsyncIO.0.1.69\lib\net40\AsyncIO.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="X86" location="Packages\Bonsai.Pylon.0.3.0\build\net462\bin\x86\Basler.Pylon.dll" />


### PR DESCRIPTION
This PR integrates the upgrades required for pulling subject records directly from the new database schema, as described in https://github.com/SainsburyWellcomeCentre/aeon_acquisition/pull/183.