### PR TITLE
Update core vision packages for circle fixes

### DIFF
--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -26,8 +26,8 @@
     <Package id="Bonsai.Spinnaker" version="0.7.1" />
     <Package id="Bonsai.System" version="2.8.1" />
     <Package id="Bonsai.System.Design" version="2.8.0" />
-    <Package id="Bonsai.Vision" version="2.8.0" />
-    <Package id="Bonsai.Vision.Design" version="2.8.0" />
+    <Package id="Bonsai.Vision" version="2.8.1" />
+    <Package id="Bonsai.Vision.Design" version="2.8.1" />
     <Package id="Bonsai.Windows.Input" version="2.7.0" />
     <Package id="Bonsai.ZeroMQ" version="0.2.0" />
     <Package id="cudnn.runtime" version="8.1.0" />
@@ -136,8 +136,8 @@
     <AssemblyLocation assemblyName="Bonsai.Spinnaker" processorArchitecture="MSIL" location="Packages\Bonsai.Spinnaker.0.7.1\lib\net462\Bonsai.Spinnaker.dll" />
     <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.1\lib\net462\Bonsai.System.dll" />
     <AssemblyLocation assemblyName="Bonsai.System.Design" processorArchitecture="MSIL" location="Packages\Bonsai.System.Design.2.8.0\lib\net462\Bonsai.System.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.2.8.0\lib\net462\Bonsai.Vision.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.Design.2.8.0\lib\net462\Bonsai.Vision.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.2.8.1\lib\net462\Bonsai.Vision.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Vision.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Vision.Design.2.8.1\lib\net462\Bonsai.Vision.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Windows.Input" processorArchitecture="MSIL" location="Packages\Bonsai.Windows.Input.2.7.0\lib\net462\Bonsai.Windows.Input.dll" />
     <AssemblyLocation assemblyName="Bonsai.ZeroMQ" processorArchitecture="MSIL" location="Packages\Bonsai.ZeroMQ.0.2.0\lib\net472\Bonsai.ZeroMQ.dll" />
     <AssemblyLocation assemblyName="Harp.CameraControllerGen2" processorArchitecture="MSIL" location="Packages\Harp.CameraControllerGen2.0.1.0\lib\net462\Harp.CameraControllerGen2.dll" />


### PR DESCRIPTION
This update to the core vision packages brings fixes to editing and manipulating the `Circle` value class, which will be used to simplify the current arena calibration workflow.