### PR TITLE
Run SLEAP pose tracking on dedicated scheduler

### DIFF
--- a/workflows/social/Extensions/PoseTracking.bonsai
+++ b/workflows/social/Extensions/PoseTracking.bonsai
@@ -48,6 +48,17 @@
                 <rx:Stop xsi:nil="true" />
               </Combinator>
             </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:EventLoopScheduler" />
+            </Expression>
+            <Expression xsi:type="PropertyMapping">
+              <PropertyMappings>
+                <Property Name="Scheduler" />
+              </PropertyMappings>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:ObserveOn" />
+            </Expression>
             <Expression xsi:type="ExternalizedMapping">
               <Property Name="PathPrefix" />
               <Property Name="PoseTrackingMetadata" />
@@ -96,16 +107,19 @@
             <Edge From="2" To="3" Label="Source1" />
             <Edge From="3" To="5" Label="Source1" />
             <Edge From="4" To="5" Label="Source2" />
-            <Edge From="5" To="9" Label="Source1" />
-            <Edge From="6" To="9" Label="Source2" />
-            <Edge From="7" To="8" Label="Source1" />
-            <Edge From="8" To="9" Label="Source3" />
-            <Edge From="9" To="11" Label="Source1" />
-            <Edge From="10" To="11" Label="Source2" />
-            <Edge From="11" To="14" Label="Source1" />
-            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="5" To="8" Label="Source1" />
+            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="7" To="8" Label="Source2" />
+            <Edge From="8" To="12" Label="Source1" />
+            <Edge From="9" To="12" Label="Source2" />
+            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="11" To="12" Label="Source3" />
+            <Edge From="12" To="14" Label="Source1" />
             <Edge From="13" To="14" Label="Source2" />
-            <Edge From="14" To="15" Label="Source1" />
+            <Edge From="14" To="17" Label="Source1" />
+            <Edge From="15" To="16" Label="Source1" />
+            <Edge From="16" To="17" Label="Source2" />
+            <Edge From="17" To="18" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>


### PR DESCRIPTION
Following the removal of `ObserveOn` from the shared video source acquisition packages, it was observed that the SLEAP tracking pipeline was lagging from excessive load on the acquisition thread. To work around this we decided to run SLEAP on a dedicated thread. After testing the performance seems to have got back to normal.