### PR TITLE
Revert channel map to original on AEON3

### DIFF
--- a/workflows/social/channelmap.yml
+++ b/workflows/social/channelmap.yml
@@ -13,11 +13,11 @@ rooms:
       interpolationMethod: Zero
   AEON3:
     coldWhite:
-      channels: [5, 7]
+      channels: [3, 7]
       interpolationMethod: Linear
       calibrationFile: aeon3_coldwhite_calibration.csv
     warmWhite:
-      channels: [3, 18, 35, 25, 38, 19]
+      channels: [5, 18, 35, 25, 38, 19]
       interpolationMethod: Zero
     red:
       channels: [13, 4, 28, 39]


### PR DESCRIPTION
This PR reverts the channel map in AEON3 rig to use only cold white as it was initially intended.
The light was fixed by ops team.