### PR TITLE
Make light monitor webcam optional

### DIFF
--- a/workflows/social/Extensions/ControlPanel.bonsai
+++ b/workflows/social/Extensions/ControlPanel.bonsai
@@ -6,7 +6,6 @@
                  xmlns:wie="clr-namespace:Bonsai.Windows.Input;assembly=Bonsai.Windows.Input"
                  xmlns:dsp="clr-namespace:Bonsai.Dsp;assembly=Bonsai.Dsp"
                  xmlns:viz="clr-namespace:Bonsai.Design.Visualizers;assembly=Bonsai.Design.Visualizers"
-                 xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
                  xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
                  xmlns:aeon-frg="clr-namespace:Aeon.Foraging;assembly=Aeon.Foraging"
@@ -474,11 +473,8 @@
               <Selector>Value</Selector>
             </Expression>
             <Expression xsi:type="VisualizerMapping" />
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="cv:CameraCapture">
-                <cv:Index>0</cv:Index>
-                <cv:CaptureProperties />
-              </Combinator>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>LightMonitor</Name>
             </Expression>
             <Expression xsi:type="VisualizerMapping" />
             <Expression xsi:type="viz:TableLayoutPanelBuilder">

--- a/workflows/social/Extensions/Declarations.bonsai
+++ b/workflows/social/Extensions/Declarations.bonsai
@@ -8,6 +8,7 @@
                  xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
                  xmlns:aeon-frg="clr-namespace:Aeon.Foraging;assembly=Aeon.Foraging"
                  xmlns:p1="clr-namespace:Harp.OutputExpander;assembly=Harp.OutputExpander"
+                 xmlns:p2="clr-namespace:OpenCV.Net;assembly=OpenCV.Net"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
@@ -80,6 +81,9 @@
       <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:PathController.bonsai">
         <Path>Z:\aeon\data\processed</Path>
         <PathName>ModelPathPrefix</PathName>
+      </Expression>
+      <Expression xsi:type="rx:PublishSubject" TypeArguments="p2:IplImage">
+        <rx:Name>LightMonitor</rx:Name>
       </Expression>
     </Nodes>
     <Edges />

--- a/workflows/social/Social-AEON3.bonsai
+++ b/workflows/social/Social-AEON3.bonsai
@@ -8,6 +8,7 @@
                  xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
                  xmlns:aeon-frg="clr-namespace:Aeon.Foraging;assembly=Aeon.Foraging"
                  xmlns:aeon-env="clr-namespace:Aeon.Environment;assembly=Aeon.Environment"
+                 xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
     <Nodes>
@@ -1793,9 +1794,19 @@ new(Value.Id as Id,
         <BlockDueTimeMin>0</BlockDueTimeMin>
         <BlockDueTimeMax>0</BlockDueTimeMax>
       </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="cv:CameraCapture">
+          <cv:Index>0</cv:Index>
+          <cv:CaptureProperties />
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="MulticastSubject">
+        <Name>LightMonitor</Name>
+      </Expression>
     </Nodes>
     <Edges>
       <Edge From="6" To="7" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/workflows/social/Social-AEON3.bonsai.layout
+++ b/workflows/social/Social-AEON3.bonsai.layout
@@ -2447,4 +2447,28 @@
     </Size>
     <WindowState>Normal</WindowState>
   </DialogSettings>
+  <DialogSettings>
+    <Visible>false</Visible>
+    <Location>
+      <X>0</X>
+      <Y>0</Y>
+    </Location>
+    <Size>
+      <Width>0</Width>
+      <Height>0</Height>
+    </Size>
+    <WindowState>Normal</WindowState>
+  </DialogSettings>
+  <DialogSettings>
+    <Visible>false</Visible>
+    <Location>
+      <X>0</X>
+      <Y>0</Y>
+    </Location>
+    <Size>
+      <Width>0</Width>
+      <Height>0</Height>
+    </Size>
+    <WindowState>Normal</WindowState>
+  </DialogSettings>
 </VisualizerLayout>


### PR DESCRIPTION
This PR makes the light monitor webcam optional for social experiments. This is a workaround to deal with the hardware issue on AEON4 which has been currently traced back to the webcam being used for monitoring the room light state.

Fixes #394 