### PR TITLE
Update SLEAP dependency to fix identity index

### DIFF
--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -21,7 +21,7 @@
     <Package id="Bonsai.Pylon" version="0.3.0" />
     <Package id="Bonsai.Scripting.Expressions" version="2.8.0" />
     <Package id="Bonsai.Scripting.Expressions.Design" version="2.8.0" />
-    <Package id="Bonsai.Sleap" version="0.2.0" />
+    <Package id="Bonsai.Sleap" version="0.2.1" />
     <Package id="Bonsai.Sleap.Design" version="0.2.0" />
     <Package id="Bonsai.Spinnaker" version="0.7.1" />
     <Package id="Bonsai.System" version="2.8.1" />
@@ -134,7 +134,7 @@
     <AssemblyLocation assemblyName="Bonsai.Scripting.Expressions.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.Expressions.Design.2.8.0\lib\net462\Bonsai.Scripting.Expressions.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.2.8.0\lib\net462\Bonsai.Scripting.IronPython.dll" />
     <AssemblyLocation assemblyName="Bonsai.Scripting.IronPython.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Scripting.IronPython.Design.2.8.0\lib\net462\Bonsai.Scripting.IronPython.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Sleap" processorArchitecture="MSIL" location="Packages\Bonsai.Sleap.0.2.0\lib\net472\Bonsai.Sleap.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Sleap" processorArchitecture="MSIL" location="Packages\Bonsai.Sleap.0.2.1\lib\net472\Bonsai.Sleap.dll" />
     <AssemblyLocation assemblyName="Bonsai.Sleap.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Sleap.Design.0.2.0\lib\net472\Bonsai.Sleap.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Spinnaker" processorArchitecture="MSIL" location="Packages\Bonsai.Spinnaker.0.7.1\lib\net462\Bonsai.Spinnaker.dll" />
     <AssemblyLocation assemblyName="Bonsai.System" processorArchitecture="MSIL" location="Packages\Bonsai.System.2.8.1\lib\net462\Bonsai.System.dll" />


### PR DESCRIPTION
This PR updates the SLEAP package containing a fix for the `GetMaximumConfidencePoseIdentity` operator as described in https://github.com/bonsai-rx/sleap/pull/17.

Fixes #420 