### PR TITLE
Update acquisition package for JSON state recovery

### DIFF
--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Aeon.Acquisition" version="0.5.0-build231204" />
+    <Package id="Aeon.Acquisition" version="0.5.0-build231205" />
     <Package id="Aeon.Database" version="0.1.0-build231020" />
     <Package id="Aeon.Environment" version="0.1.0-build231209" />
     <Package id="Aeon.Foraging" version="0.1.0-build231201" />
@@ -109,7 +109,7 @@
     <AssemblyReference assemblyName="Harp.TimestampGeneratorGen3" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Aeon.Acquisition" processorArchitecture="MSIL" location="Packages\Aeon.Acquisition.0.5.0-build231204\lib\net472\Aeon.Acquisition.dll" />
+    <AssemblyLocation assemblyName="Aeon.Acquisition" processorArchitecture="MSIL" location="Packages\Aeon.Acquisition.0.5.0-build231205\lib\net472\Aeon.Acquisition.dll" />
     <AssemblyLocation assemblyName="Aeon.Database" processorArchitecture="MSIL" location="Packages\Aeon.Database.0.1.0-build231020\lib\net472\Aeon.Database.dll" />
     <AssemblyLocation assemblyName="Aeon.Environment" processorArchitecture="MSIL" location="Packages\Aeon.Environment.0.1.0-build231209\lib\net472\Aeon.Environment.dll" />
     <AssemblyLocation assemblyName="Aeon.Foraging" processorArchitecture="MSIL" location="Packages\Aeon.Foraging.0.1.0-build231201\lib\net472\Aeon.Foraging.dll" />


### PR DESCRIPTION
This PR updates the acquisition package version to allow for JSON-based state recovery of environment definition files as per https://github.com/SainsburyWellcomeCentre/aeon_acquisition/pull/197.