### PR TITLE
Ensure nest weight baseline is taken

### DIFF
--- a/workflows/social/Extensions/Declarations.bonsai
+++ b/workflows/social/Extensions/Declarations.bonsai
@@ -37,7 +37,7 @@
       <Expression xsi:type="aeon:StateRecoverySubject" TypeArguments="sys:ValueTuple(sys:Int32,sys:Int32,sys:Double)">
         <aeon:Name>BlockState</aeon:Name>
       </Expression>
-      <Expression xsi:type="rx:PublishSubject" TypeArguments="harp:Timestamped(sys:Double)">
+      <Expression xsi:type="rx:PublishSubject" TypeArguments="harp:Timestamped(sys:Int32)">
         <rx:Name>BaselineTrigger</rx:Name>
       </Expression>
       <Expression xsi:type="rx:BehaviorSubject" TypeArguments="harp:Timestamped(aeon:LogMessage)">

--- a/workflows/social/Extensions/Visualization.bonsai
+++ b/workflows/social/Extensions/Visualization.bonsai
@@ -758,7 +758,7 @@ Item3 as Patch3)</scr:Expression>
         <Name>NestWeightData</Name>
       </Expression>
       <Expression xsi:type="MemberSelector">
-        <Selector>FilteredWeight</Selector>
+        <Selector>BaselinedWeight</Selector>
       </Expression>
       <Expression xsi:type="rx:Condition">
         <Name>StableWeight</Name>
@@ -1085,50 +1085,71 @@ IdentityIndex as IdentityIndex)</scr:Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>SubjectsInArena</Name>
       </Expression>
-      <Expression xsi:type="MemberSelector">
-        <Selector>Value.Count</Selector>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="rx:DistinctUntilChanged" />
-      </Expression>
-      <Expression xsi:type="ExternalizedMapping">
-        <Property Name="DueTime" DisplayName="BaselineRefractoryPeriod" />
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="rx:Throttle">
-          <rx:DueTime>PT0S</rx:DueTime>
-        </Combinator>
-      </Expression>
-      <Expression xsi:type="rx:Condition">
+      <Expression xsi:type="GroupWorkflow">
+        <Name>StableSubjectCount</Name>
         <Workflow>
           <Nodes>
             <Expression xsi:type="WorkflowInput">
               <Name>Source1</Name>
             </Expression>
-            <Expression xsi:type="Equal">
-              <Operand xsi:type="IntProperty">
-                <Value>2</Value>
-              </Operand>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value.Count</Selector>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:DistinctUntilChanged" />
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="DueTime" DisplayName="StabilityPeriod" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Throttle">
+                <rx:DueTime>PT0S</rx:DueTime>
+              </Combinator>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
           </Nodes>
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
             <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="4" Label="Source1" />
+            <Edge From="3" To="4" Label="Source2" />
+            <Edge From="4" To="5" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
       <Expression xsi:type="SubscribeSubject">
-        <Name>ActivityCenter</Name>
+        <Name>SubjectPoses</Name>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Value.Count</Selector>
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:WithLatestFrom" />
       </Expression>
+      <Expression xsi:type="scr:ExpressionCondition">
+        <scr:Name>AllSubjectsInArena</scr:Name>
+        <scr:Expression>Item1 &gt; 0 &amp;&amp; Item1 == Item2</scr:Expression>
+      </Expression>
       <Expression xsi:type="MemberSelector">
-        <Selector>Item2</Selector>
+        <Selector>Item1</Selector>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>ActivityCenter</Name>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Seconds</Selector>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:WithLatestFrom" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="harp:CreateTimestamped" />
       </Expression>
       <Expression xsi:type="MulticastSubject">
         <Name>BaselineTrigger</Name>
+      </Expression>
+      <Expression xsi:type="MulticastSubject">
+        <Name>NestBaselineWeight</Name>
       </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>SubjectWeight</Name>
@@ -1361,23 +1382,24 @@ Item1.Value as CurrentWeight,
       <Edge From="142" To="143" Label="Source1" />
       <Edge From="143" To="144" Label="Source1" />
       <Edge From="145" To="146" Label="Source1" />
-      <Edge From="146" To="147" Label="Source1" />
-      <Edge From="147" To="149" Label="Source1" />
+      <Edge From="146" To="149" Label="Source1" />
+      <Edge From="147" To="148" Label="Source1" />
       <Edge From="148" To="149" Label="Source2" />
       <Edge From="149" To="150" Label="Source1" />
-      <Edge From="150" To="152" Label="Source1" />
-      <Edge From="151" To="152" Label="Source2" />
+      <Edge From="150" To="151" Label="Source1" />
+      <Edge From="151" To="154" Label="Source1" />
       <Edge From="152" To="153" Label="Source1" />
-      <Edge From="153" To="154" Label="Source1" />
-      <Edge From="155" To="158" Label="Source1" />
+      <Edge From="153" To="154" Label="Source2" />
+      <Edge From="154" To="155" Label="Source1" />
+      <Edge From="155" To="156" Label="Source1" />
       <Edge From="156" To="157" Label="Source1" />
-      <Edge From="157" To="158" Label="Source2" />
-      <Edge From="158" To="159" Label="Source1" />
+      <Edge From="158" To="161" Label="Source1" />
       <Edge From="159" To="160" Label="Source1" />
+      <Edge From="160" To="161" Label="Source2" />
       <Edge From="161" To="162" Label="Source1" />
-      <Edge From="163" To="164" Label="Source1" />
-      <Edge From="165" To="166" Label="Source1" />
-      <Edge From="167" To="168" Label="Source1" />
+      <Edge From="162" To="163" Label="Source1" />
+      <Edge From="164" To="165" Label="Source1" />
+      <Edge From="166" To="167" Label="Source1" />
       <Edge From="168" To="169" Label="Source1" />
       <Edge From="170" To="171" Label="Source1" />
       <Edge From="171" To="172" Label="Source1" />
@@ -1389,6 +1411,8 @@ Item1.Value as CurrentWeight,
       <Edge From="180" To="181" Label="Source1" />
       <Edge From="182" To="183" Label="Source1" />
       <Edge From="183" To="184" Label="Source1" />
+      <Edge From="185" To="186" Label="Source1" />
+      <Edge From="186" To="187" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/workflows/social/Social-AEON3.bonsai
+++ b/workflows/social/Social-AEON3.bonsai
@@ -929,9 +929,7 @@
         </Workflow>
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\Declarations.bonsai" />
-      <Expression xsi:type="IncludeWorkflow" Path="Extensions\Visualization.bonsai">
-        <BaselineRefractoryPeriod>PT0S</BaselineRefractoryPeriod>
-      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Extensions\Visualization.bonsai" />
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\Alerts.bonsai" />
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\Logging.bonsai" />
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\ControlPanel.bonsai" />

--- a/workflows/social/Social-AEON4.bonsai
+++ b/workflows/social/Social-AEON4.bonsai
@@ -929,9 +929,7 @@
         </Workflow>
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\Declarations.bonsai" />
-      <Expression xsi:type="IncludeWorkflow" Path="Extensions\Visualization.bonsai">
-        <BaselineRefractoryPeriod>PT0S</BaselineRefractoryPeriod>
-      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Extensions\Visualization.bonsai" />
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\Alerts.bonsai" />
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\Logging.bonsai" />
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\ControlPanel.bonsai" />

--- a/workflows/social/Social-Simulator.bonsai
+++ b/workflows/social/Social-Simulator.bonsai
@@ -418,9 +418,7 @@
         </Workflow>
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\Declarations.bonsai" />
-      <Expression xsi:type="IncludeWorkflow" Path="Extensions\Visualization.bonsai">
-        <BaselineRefractoryPeriod>PT0S</BaselineRefractoryPeriod>
-      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Extensions\Visualization.bonsai" />
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\ControlPanel.bonsai" />
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="EnvironmentConfigPath" />


### PR DESCRIPTION
This PR updates the weight scale baseline logic to work for any number of subjects placed in the environment, and ensures that the baseline command is actually sent to the scale device and that the baselined weight is used to compute the stream of subject weights.

Fixes #427 
Fixes #298 