### PR TITLE
Add maintenance timeout alert

### DIFF
--- a/workflows/social/Extensions/Alerts.bonsai
+++ b/workflows/social/Extensions/Alerts.bonsai
@@ -1249,6 +1249,19 @@ Mode: {1}</Format>
             <Expression xsi:type="MulticastSubject">
               <Name>EnvironmentAlertMessages</Name>
             </Expression>
+            <Expression xsi:type="IncludeWorkflow" Path="Bonsai.Harp:WithLatestTimestamp.bonsai">
+              <Name>VideoEvents</Name>
+            </Expression>
+            <Expression xsi:type="aeon:FormatLogMessage">
+              <Format />
+              <Selector>Value</Selector>
+              <aeon:Priority>Alert</aeon:Priority>
+              <aeon:Type>MaintenanceTimeout</aeon:Type>
+              <aeon:Timestamp>Seconds</aeon:Timestamp>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>AlertLogs</Name>
+            </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>VideoEvents</Name>
             </Expression>
@@ -1557,33 +1570,36 @@ Item2.GetTimestamp() as Timestamp)</scr:Expression>
             <Edge From="15" To="16" Label="Source1" />
             <Edge From="16" To="17" Label="Source1" />
             <Edge From="17" To="18" Label="Source1" />
+            <Edge From="17" To="21" Label="Source1" />
             <Edge From="18" To="19" Label="Source1" />
             <Edge From="19" To="20" Label="Source1" />
             <Edge From="21" To="22" Label="Source1" />
             <Edge From="22" To="23" Label="Source1" />
-            <Edge From="23" To="24" Label="Source1" />
-            <Edge From="24" To="26" Label="Source1" />
-            <Edge From="25" To="26" Label="Source2" />
+            <Edge From="24" To="25" Label="Source1" />
+            <Edge From="25" To="26" Label="Source1" />
             <Edge From="26" To="27" Label="Source1" />
-            <Edge From="26" To="29" Label="Source1" />
-            <Edge From="27" To="28" Label="Source1" />
+            <Edge From="27" To="29" Label="Source1" />
+            <Edge From="28" To="29" Label="Source2" />
             <Edge From="29" To="30" Label="Source1" />
-            <Edge From="31" To="32" Label="Source1" />
-            <Edge From="31" To="34" Label="Source1" />
+            <Edge From="29" To="32" Label="Source1" />
+            <Edge From="30" To="31" Label="Source1" />
             <Edge From="32" To="33" Label="Source1" />
             <Edge From="34" To="35" Label="Source1" />
-            <Edge From="36" To="37" Label="Source1" />
+            <Edge From="34" To="37" Label="Source1" />
+            <Edge From="35" To="36" Label="Source1" />
             <Edge From="37" To="38" Label="Source1" />
-            <Edge From="38" To="39" Label="Source1" />
+            <Edge From="39" To="40" Label="Source1" />
             <Edge From="40" To="41" Label="Source1" />
             <Edge From="41" To="42" Label="Source1" />
-            <Edge From="41" To="48" Label="Source1" />
-            <Edge From="42" To="43" Label="Source1" />
             <Edge From="43" To="44" Label="Source1" />
-            <Edge From="43" To="46" Label="Source1" />
             <Edge From="44" To="45" Label="Source1" />
+            <Edge From="44" To="51" Label="Source1" />
+            <Edge From="45" To="46" Label="Source1" />
             <Edge From="46" To="47" Label="Source1" />
-            <Edge From="48" To="49" Label="Source1" />
+            <Edge From="46" To="49" Label="Source1" />
+            <Edge From="47" To="48" Label="Source1" />
+            <Edge From="49" To="50" Label="Source1" />
+            <Edge From="51" To="52" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>


### PR DESCRIPTION
This PR adds a new alert for maintenance mode timeout, which is defined as leaving the arena running in maintenance mode for a specified period (default 15min). At alert trigger, the original time at which maintenance started is reported in both the alert card and the logs.

Fixes #108 