### PR TITLE
Fix reference to obsolete fields in block state

### DIFF
--- a/workflows/social/Extensions/Logging.bonsai
+++ b/workflows/social/Extensions/Logging.bonsai
@@ -469,12 +469,6 @@ Item3 as Delta)</scr:Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>BlockState</Name>
       </Expression>
-      <Expression xsi:type="scr:ExpressionTransform">
-        <scr:Expression>new(
-Item1 as BlockPelletCount,
-Item2 as BlockThreshold,
-Item3 as BlockDueTime)</scr:Expression>
-      </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Bonsai.Harp:WithLatestTimestamp.bonsai">
         <Name>Patch1Events</Name>
       </Expression>
@@ -791,54 +785,53 @@ new(Value.Id as Id,
       <Edge From="79" To="80" Label="Source1" />
       <Edge From="81" To="82" Label="Source1" />
       <Edge From="82" To="83" Label="Source1" />
-      <Edge From="83" To="84" Label="Source1" />
-      <Edge From="85" To="86" Label="Source1" />
-      <Edge From="87" To="88" Label="Source1" />
-      <Edge From="89" To="91" Label="Source1" />
-      <Edge From="90" To="91" Label="Source2" />
-      <Edge From="91" To="92" Label="Source1" />
-      <Edge From="93" To="94" Label="Source1" />
-      <Edge From="95" To="96" Label="Source1" />
-      <Edge From="97" To="98" Label="Source1" />
-      <Edge From="98" To="111" Label="Source1" />
-      <Edge From="99" To="100" Label="Source1" />
-      <Edge From="100" To="111" Label="Source2" />
-      <Edge From="101" To="102" Label="Source1" />
-      <Edge From="102" To="111" Label="Source3" />
-      <Edge From="103" To="104" Label="Source1" />
-      <Edge From="104" To="111" Label="Source4" />
-      <Edge From="105" To="106" Label="Source1" />
-      <Edge From="106" To="111" Label="Source5" />
-      <Edge From="107" To="108" Label="Source1" />
-      <Edge From="108" To="111" Label="Source6" />
-      <Edge From="109" To="110" Label="Source1" />
-      <Edge From="110" To="111" Label="Source7" />
+      <Edge From="84" To="85" Label="Source1" />
+      <Edge From="86" To="87" Label="Source1" />
+      <Edge From="88" To="90" Label="Source1" />
+      <Edge From="89" To="90" Label="Source2" />
+      <Edge From="90" To="91" Label="Source1" />
+      <Edge From="92" To="93" Label="Source1" />
+      <Edge From="94" To="95" Label="Source1" />
+      <Edge From="96" To="97" Label="Source1" />
+      <Edge From="97" To="110" Label="Source1" />
+      <Edge From="98" To="99" Label="Source1" />
+      <Edge From="99" To="110" Label="Source2" />
+      <Edge From="100" To="101" Label="Source1" />
+      <Edge From="101" To="110" Label="Source3" />
+      <Edge From="102" To="103" Label="Source1" />
+      <Edge From="103" To="110" Label="Source4" />
+      <Edge From="104" To="105" Label="Source1" />
+      <Edge From="105" To="110" Label="Source5" />
+      <Edge From="106" To="107" Label="Source1" />
+      <Edge From="107" To="110" Label="Source6" />
+      <Edge From="108" To="109" Label="Source1" />
+      <Edge From="109" To="110" Label="Source7" />
+      <Edge From="110" To="111" Label="Source1" />
       <Edge From="111" To="112" Label="Source1" />
-      <Edge From="112" To="113" Label="Source1" />
-      <Edge From="114" To="115" Label="Source1" />
-      <Edge From="116" To="117" Label="Source1" />
-      <Edge From="118" To="119" Label="Source1" />
-      <Edge From="120" To="121" Label="Source1" />
-      <Edge From="122" To="123" Label="Source1" />
-      <Edge From="124" To="125" Label="Source1" />
-      <Edge From="126" To="127" Label="Source1" />
-      <Edge From="127" To="130" Label="Source1" />
-      <Edge From="128" To="129" Label="Source1" />
-      <Edge From="129" To="130" Label="Source2" />
+      <Edge From="113" To="114" Label="Source1" />
+      <Edge From="115" To="116" Label="Source1" />
+      <Edge From="117" To="118" Label="Source1" />
+      <Edge From="119" To="120" Label="Source1" />
+      <Edge From="121" To="122" Label="Source1" />
+      <Edge From="123" To="124" Label="Source1" />
+      <Edge From="125" To="126" Label="Source1" />
+      <Edge From="126" To="129" Label="Source1" />
+      <Edge From="127" To="128" Label="Source1" />
+      <Edge From="128" To="129" Label="Source2" />
+      <Edge From="129" To="130" Label="Source1" />
       <Edge From="130" To="131" Label="Source1" />
-      <Edge From="131" To="132" Label="Source1" />
+      <Edge From="132" To="133" Label="Source1" />
       <Edge From="133" To="134" Label="Source1" />
-      <Edge From="134" To="135" Label="Source1" />
-      <Edge From="135" To="143" Label="Source1" />
-      <Edge From="136" To="137" Label="Source1" />
-      <Edge From="137" To="143" Label="Source2" />
+      <Edge From="134" To="142" Label="Source1" />
+      <Edge From="135" To="136" Label="Source1" />
+      <Edge From="136" To="142" Label="Source2" />
+      <Edge From="137" To="138" Label="Source1" />
       <Edge From="138" To="139" Label="Source1" />
-      <Edge From="139" To="140" Label="Source1" />
-      <Edge From="140" To="143" Label="Source3" />
-      <Edge From="141" To="142" Label="Source1" />
-      <Edge From="142" To="143" Label="Source4" />
-      <Edge From="143" To="144" Label="Source1" />
-      <Edge From="145" To="146" Label="Source1" />
+      <Edge From="139" To="142" Label="Source3" />
+      <Edge From="140" To="141" Label="Source1" />
+      <Edge From="141" To="142" Label="Source4" />
+      <Edge From="142" To="143" Label="Source1" />
+      <Edge From="144" To="145" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
This PR fixes invalid references to obsolete fields in block state that were introduced when refactoring the task visualization.