### PR TITLE
Add labeled visualizer for plotting weight data

### DIFF
--- a/workflows/social/Extensions/ControlPanel.bonsai
+++ b/workflows/social/Extensions/ControlPanel.bonsai
@@ -1045,12 +1045,10 @@ P3 (rate: {8}, d0: {7}, thr: {6:0.##})</Format>
             <Expression xsi:type="SubscribeSubject">
               <Name>AverageWeights</Name>
             </Expression>
-            <Expression xsi:type="viz:RollingGraphBuilder">
-              <viz:SymbolType>None</viz:SymbolType>
-              <viz:LineWidth>1</viz:LineWidth>
-              <viz:Capacity xsi:nil="true" />
-              <viz:Min xsi:nil="true" />
-              <viz:Max xsi:nil="true" />
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="p1:LabeledSeriesVisualizerBuilder">
+                <p1:Capacity>120</p1:Capacity>
+              </Combinator>
             </Expression>
             <Expression xsi:type="VisualizerMapping" />
             <Expression xsi:type="SubscribeSubject">

--- a/workflows/social/Extensions/LabeledSeriesVisualizer.cs
+++ b/workflows/social/Extensions/LabeledSeriesVisualizer.cs
@@ -1,0 +1,109 @@
+using Bonsai;
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using Bonsai.Design;
+using ZedGraph;
+using Bonsai.Design.Visualizers;
+using System.Windows.Forms;
+using Bonsai.Expressions;
+using System.Reactive.Linq;
+using System.Linq;
+
+[Combinator]
+[Description("Display individual labeled measurements in a line plot.")]
+[WorkflowElementCategory(ElementCategory.Combinator)]
+[WorkflowElementIcon("Bonsai:ElementIcon.Visualizer")]
+[TypeVisualizer(typeof(LabeledSeriesVisualizer))]
+public class LabeledSeriesVisualizerBuilder
+{
+    public int Capacity { get; set; }
+
+    public IObservable<LabeledMeasurement[]> Process(IObservable<Tuple<double, string>[]> source)
+    {
+        return source.Select(xs => Array.ConvertAll(xs, x => new LabeledMeasurement(x.Item1, x.Item2)));
+    }
+
+    public IObservable<LabeledMeasurement[]> Process(IObservable<LabeledMeasurement[]> source)
+    {
+        return source;
+    }
+}
+
+public class LabeledSeriesVisualizer : DialogTypeVisualizer
+{
+    int capacity;
+    GraphControl graph;
+    Dictionary<string, IPointListEdit> seriesMap;
+
+    public override void Load(IServiceProvider provider)
+    {
+        var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
+        var visualizerElement = ExpressionBuilder.GetVisualizerElement(context.Source);
+        var builder = (LabeledSeriesVisualizerBuilder)ExpressionBuilder.GetWorkflowElement(visualizerElement);
+        capacity = builder.Capacity;
+
+        graph = new GraphControl();
+        graph.Dock = DockStyle.Fill;
+        var timeAxis = graph.GraphPane.XAxis;
+        timeAxis.Type = AxisType.Date;
+        timeAxis.Scale.Format = "HH:mm:ss";
+        timeAxis.Scale.MajorUnit = DateUnit.Second;
+        timeAxis.Scale.MinorUnit = DateUnit.Millisecond;
+        timeAxis.MinorTic.IsAllTics = false;
+
+        seriesMap = new Dictionary<string, IPointListEdit>();
+        var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
+        if (visualizerService != null)
+        {
+            visualizerService.AddControl(graph);
+        }
+    }
+
+    private void ShowMeasurement(DateTime timestamp, LabeledMeasurement measurement)
+    {
+        IPointListEdit series;
+        if (!seriesMap.TryGetValue(measurement.Name, out series))
+        {
+            series = capacity > 0 ? (IPointListEdit)new RollingPointPairList(capacity) : new PointPairList();
+            var curve = graph.GraphPane.AddCurve(measurement.Name, series, graph.GetNextColor(), SymbolType.Circle);
+            curve.Line.IsOptimizedDraw = true;
+            curve.Symbol.Fill.Type = FillType.Solid;
+            seriesMap.Add(measurement.Name, series);
+        }
+
+        series.Add((XDate)timestamp, measurement.Value);
+    }
+
+    public override void Show(object value)
+    {
+        var dateTime = DateTime.UtcNow;
+        var array = value as LabeledMeasurement[];
+        if (array != null)
+        {
+            for (int i = 0; i < array.Length; i++)
+            {
+                ShowMeasurement(dateTime, array[i]);
+            }
+        }
+        else ShowMeasurement(dateTime, (LabeledMeasurement)value);
+        graph.Invalidate();
+    }
+
+    public override void Unload()
+    {
+        graph.Dispose();
+    }
+}
+
+public struct LabeledMeasurement
+{
+    public double Value;
+    public string Name;
+
+    public LabeledMeasurement(double value, string name)
+    {
+        Value = value;
+        Name = name;
+    }
+}

--- a/workflows/social/Extensions/Visualization.bonsai
+++ b/workflows/social/Extensions/Visualization.bonsai
@@ -1065,9 +1065,6 @@ IdentityIndex as IdentityIndex)</scr:Expression>
                 </Edges>
               </Workflow>
             </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Item1</Selector>
-            </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="rx:ToArray" />
             </Expression>
@@ -1083,7 +1080,6 @@ IdentityIndex as IdentityIndex)</scr:Expression>
             <Edge From="5" To="6" Label="Source1" />
             <Edge From="6" To="7" Label="Source1" />
             <Edge From="7" To="8" Label="Source1" />
-            <Edge From="8" To="9" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>


### PR DESCRIPTION
This PR replaces the default rolling graph for weights with a custom labeled series visualizer. This allows for a variable number of labeled subjects, and actual series labels following the class name.

Fixes #469 