### PR TITLE
Update environment package for RFID event filters

### DIFF
--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Aeon.Acquisition" version="0.5.0-build231205" />
+    <Package id="Aeon.Acquisition" version="0.5.0-build240101" />
     <Package id="Aeon.Database" version="0.1.0-build231020" />
-    <Package id="Aeon.Environment" version="0.1.0-build231209" />
+    <Package id="Aeon.Environment" version="0.1.0-build240101" />
     <Package id="Aeon.Foraging" version="0.1.0-build231202" />
     <Package id="AsyncIO" version="0.1.69" />
     <Package id="Bonsai" version="2.8.1" />
@@ -109,9 +109,9 @@
     <AssemblyReference assemblyName="Harp.TimestampGeneratorGen3" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Aeon.Acquisition" processorArchitecture="MSIL" location="Packages\Aeon.Acquisition.0.5.0-build231205\lib\net472\Aeon.Acquisition.dll" />
+    <AssemblyLocation assemblyName="Aeon.Acquisition" processorArchitecture="MSIL" location="Packages\Aeon.Acquisition.0.5.0-build240101\lib\net472\Aeon.Acquisition.dll" />
     <AssemblyLocation assemblyName="Aeon.Database" processorArchitecture="MSIL" location="Packages\Aeon.Database.0.1.0-build231020\lib\net472\Aeon.Database.dll" />
-    <AssemblyLocation assemblyName="Aeon.Environment" processorArchitecture="MSIL" location="Packages\Aeon.Environment.0.1.0-build231209\lib\net472\Aeon.Environment.dll" />
+    <AssemblyLocation assemblyName="Aeon.Environment" processorArchitecture="MSIL" location="Packages\Aeon.Environment.0.1.0-build240101\lib\net472\Aeon.Environment.dll" />
     <AssemblyLocation assemblyName="Aeon.Foraging" processorArchitecture="MSIL" location="Packages\Aeon.Foraging.0.1.0-build231202\lib\net472\Aeon.Foraging.dll" />
     <AssemblyLocation assemblyName="AsyncIO" processorArchitecture="MSIL" location="Packages\AsyncIO.0.1.69\lib\net40\AsyncIO.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="X86" location="Packages\Bonsai.Pylon.0.3.0\build\net462\bin\x86\Basler.Pylon.dll" />


### PR DESCRIPTION
This PR updates the environment package to provide support for RFID event filtering where only inbound detection events are propagated through the event subject as per https://github.com/SainsburyWellcomeCentre/aeon_acquisition/pull/203.

The acquisition package was also updated with a new static method to support easier Harp timestamp to datetime conversion: https://github.com/SainsburyWellcomeCentre/aeon_acquisition/pull/200.