### PR TITLE
Add timeout notifications for all camera streams

### DIFF
--- a/workflows/social/Extensions/Alerts.bonsai
+++ b/workflows/social/Extensions/Alerts.bonsai
@@ -1522,6 +1522,104 @@ Item2.GetTimestamp() as Timestamp)</scr:Expression>
             <Expression xsi:type="MulticastSubject">
               <Name>AlertLogs</Name>
             </Expression>
+            <Expression xsi:type="GroupWorkflow">
+              <Name>StreamTimeoutMonitor</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="IncludeWorkflow" Path="Extensions\StreamTimeout.bonsai">
+                    <StreamEvents>CameraTop</StreamEvents>
+                    <DueTime>PT1S</DueTime>
+                  </Expression>
+                  <Expression xsi:type="IncludeWorkflow" Path="Extensions\StreamTimeout.bonsai">
+                    <StreamEvents>CameraWest</StreamEvents>
+                    <DueTime>PT1S</DueTime>
+                  </Expression>
+                  <Expression xsi:type="IncludeWorkflow" Path="Extensions\StreamTimeout.bonsai">
+                    <StreamEvents>CameraEast</StreamEvents>
+                    <DueTime>PT1S</DueTime>
+                  </Expression>
+                  <Expression xsi:type="IncludeWorkflow" Path="Extensions\StreamTimeout.bonsai">
+                    <StreamEvents>CameraNorth</StreamEvents>
+                    <DueTime>PT1S</DueTime>
+                  </Expression>
+                  <Expression xsi:type="IncludeWorkflow" Path="Extensions\StreamTimeout.bonsai">
+                    <StreamEvents>CameraSouth</StreamEvents>
+                    <DueTime>PT1S</DueTime>
+                  </Expression>
+                  <Expression xsi:type="IncludeWorkflow" Path="Extensions\StreamTimeout.bonsai">
+                    <StreamEvents>CameraNest</StreamEvents>
+                    <DueTime>PT1S</DueTime>
+                  </Expression>
+                  <Expression xsi:type="IncludeWorkflow" Path="Extensions\StreamTimeout.bonsai">
+                    <StreamEvents>CameraPatch1</StreamEvents>
+                    <DueTime>PT1S</DueTime>
+                  </Expression>
+                  <Expression xsi:type="IncludeWorkflow" Path="Extensions\StreamTimeout.bonsai">
+                    <StreamEvents>CameraPatch2</StreamEvents>
+                    <DueTime>PT1S</DueTime>
+                  </Expression>
+                  <Expression xsi:type="IncludeWorkflow" Path="Extensions\StreamTimeout.bonsai">
+                    <StreamEvents>CameraPatch3</StreamEvents>
+                    <DueTime>PT1S</DueTime>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Merge" />
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>StartCameras</Name>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:SubscribeWhen" />
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>StopCameras</Name>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:TakeUntil" />
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Repeat" />
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="9" Label="Source1" />
+                  <Edge From="1" To="9" Label="Source2" />
+                  <Edge From="2" To="9" Label="Source3" />
+                  <Edge From="3" To="9" Label="Source4" />
+                  <Edge From="4" To="9" Label="Source5" />
+                  <Edge From="5" To="9" Label="Source6" />
+                  <Edge From="6" To="9" Label="Source7" />
+                  <Edge From="7" To="9" Label="Source8" />
+                  <Edge From="8" To="9" Label="Source9" />
+                  <Edge From="9" To="11" Label="Source1" />
+                  <Edge From="10" To="11" Label="Source2" />
+                  <Edge From="11" To="13" Label="Source1" />
+                  <Edge From="12" To="13" Label="Source2" />
+                  <Edge From="13" To="14" Label="Source1" />
+                  <Edge From="14" To="15" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="Format">
+              <Format>## **Stream Timeout**
+**Stream**: {0}
+</Format>
+              <Selector>Value</Selector>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>EnvironmentAlertMessages</Name>
+            </Expression>
+            <Expression xsi:type="aeon:FormatLogMessage">
+              <Format />
+              <Selector>Value</Selector>
+              <aeon:Priority>Alert</aeon:Priority>
+              <aeon:Type>StreamTimeout</aeon:Type>
+              <aeon:Timestamp>Seconds</aeon:Timestamp>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>AlertLogs</Name>
+            </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>Annotations</Name>
             </Expression>
@@ -1664,17 +1762,21 @@ Item2.GetTimestamp() as Timestamp)</scr:Expression>
             <Edge From="35" To="36" Label="Source1" />
             <Edge From="37" To="38" Label="Source1" />
             <Edge From="39" To="40" Label="Source1" />
+            <Edge From="39" To="42" Label="Source1" />
             <Edge From="40" To="41" Label="Source1" />
-            <Edge From="41" To="42" Label="Source1" />
-            <Edge From="43" To="44" Label="Source1" />
+            <Edge From="42" To="43" Label="Source1" />
             <Edge From="44" To="45" Label="Source1" />
-            <Edge From="44" To="51" Label="Source1" />
             <Edge From="45" To="46" Label="Source1" />
             <Edge From="46" To="47" Label="Source1" />
-            <Edge From="46" To="49" Label="Source1" />
-            <Edge From="47" To="48" Label="Source1" />
+            <Edge From="48" To="49" Label="Source1" />
             <Edge From="49" To="50" Label="Source1" />
+            <Edge From="49" To="56" Label="Source1" />
+            <Edge From="50" To="51" Label="Source1" />
             <Edge From="51" To="52" Label="Source1" />
+            <Edge From="51" To="54" Label="Source1" />
+            <Edge From="52" To="53" Label="Source1" />
+            <Edge From="54" To="55" Label="Source1" />
+            <Edge From="56" To="57" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/workflows/social/Extensions/StreamTimeout.bonsai
+++ b/workflows/social/Extensions/StreamTimeout.bonsai
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.1"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
+                 xmlns:spk="clr-namespace:Bonsai.Spinnaker;assembly=Bonsai.Spinnaker"
+                 xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Description>Detects that the specified stream stopped producing values.</Description>
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="StreamEvents" />
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>StreamEvents</Name>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="DueTime" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:TimeoutNotification.bonsai">
+        <DueTime>PT1S</DueTime>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Value" DisplayName="Name" />
+            </Expression>
+            <Expression xsi:type="PropertySource" TypeArguments="SubscribeSubject(harp:Timestamped(spk:SpinnakerDataFrame)),sys:String">
+              <MemberName>Name</MemberName>
+              <Value>StreamEvents</Value>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Take">
+                <rx:Count>1</rx:Count>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Heartbeats</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:CombineLatest" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Item2,Item3</Selector>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="harp:CreateTimestamped" />
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="0" To="4" Label="Source1" />
+      <Edge From="1" To="3" Label="Source1" />
+      <Edge From="2" To="3" Label="Source2" />
+      <Edge From="3" To="6" Label="Source1" />
+      <Edge From="4" To="6" Label="Source2" />
+      <Edge From="5" To="6" Label="Source3" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>


### PR DESCRIPTION
This PR adds timeout detection for all camera streams, starting from the moment when camera triggering starts until the moment when cameras are paused. Any notifications are sent as an alert with the corresponding camera name.

The base implementation was taken from #246 which was lost when porting components to the full social workflow.

Fixes #129 