### PR TITLE
Add sln to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Packages
 *.avi
 *.dll
 *.exe
+*.sln
 *.exe.settings
 *.WebView2
 SessionSummary


### PR DESCRIPTION
This fix the annoyance of C# Dev kit always creating unnecessary sln files in the git folders.

Fixes #488