### PR TITLE
Remove repeat every subject from environment logic

### DIFF
--- a/workflows/social/Extensions/EnvironmentLogic.bonsai
+++ b/workflows/social/Extensions/EnvironmentLogic.bonsai
@@ -769,7 +769,6 @@ RatePatch3 as Rate)</scr:Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:Repeat" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RepeatEverySubject.bonsai" />
       <Expression xsi:type="SubscribeSubject">
         <Name>BlockTransitionEvent</Name>
       </Expression>
@@ -854,8 +853,7 @@ RatePatch3 as Rate)</scr:Expression>
       <Edge From="9" To="10" Label="Source1" />
       <Edge From="10" To="11" Label="Source1" />
       <Edge From="11" To="12" Label="Source1" />
-      <Edge From="12" To="13" Label="Source1" />
-      <Edge From="14" To="15" Label="Source1" />
+      <Edge From="13" To="14" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/workflows/social/Extensions/Visualization.bonsai
+++ b/workflows/social/Extensions/Visualization.bonsai
@@ -185,7 +185,6 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:WithLatestFrom" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RepeatEverySubject.bonsai" />
       <Expression xsi:type="scr:ExpressionTransform">
         <scr:Expression>new(
 int32(Item2) as PelletCount,
@@ -269,7 +268,6 @@ Item1 as Threshold)</scr:Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:WithLatestFrom" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RepeatEverySubject.bonsai" />
       <Expression xsi:type="scr:ExpressionTransform">
         <scr:Expression>new(
 int32(Item2) as PelletCount,
@@ -353,7 +351,6 @@ Item1 as Threshold)</scr:Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:WithLatestFrom" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RepeatEverySubject.bonsai" />
       <Expression xsi:type="scr:ExpressionTransform">
         <scr:Expression>new(
 int32(Item2) as PelletCount,
@@ -480,7 +477,6 @@ Item3 as Patch3)</scr:Expression>
         <Combinator xsi:type="rx:CombineLatest" />
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\RepeatEveryBlock.bonsai" />
-      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RepeatEverySubject.bonsai" />
       <Expression xsi:type="scr:ExpressionTransform">
         <scr:Expression>new(
 "Total Distance Travelled (cm)" as Id,
@@ -503,7 +499,6 @@ Item3 as Patch3)</scr:Expression>
         <LowPass>1</LowPass>
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\RepeatEveryBlock.bonsai" />
-      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RepeatEverySubject.bonsai" />
       <Expression xsi:type="rx:BehaviorSubject">
         <Name>Patch1TimeSpent</Name>
       </Expression>
@@ -511,7 +506,6 @@ Item3 as Patch3)</scr:Expression>
         <Name>Patch1TimeSpent</Name>
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\RepeatEveryBlock.bonsai" />
-      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RepeatEverySubject.bonsai" />
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:DistinctUntilChanged" />
       </Expression>
@@ -526,7 +520,6 @@ Item3 as Patch3)</scr:Expression>
         <LowPass>1</LowPass>
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\RepeatEveryBlock.bonsai" />
-      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RepeatEverySubject.bonsai" />
       <Expression xsi:type="rx:BehaviorSubject">
         <Name>Patch2TimeSpent</Name>
       </Expression>
@@ -534,7 +527,6 @@ Item3 as Patch3)</scr:Expression>
         <Name>Patch2TimeSpent</Name>
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\RepeatEveryBlock.bonsai" />
-      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RepeatEverySubject.bonsai" />
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:DistinctUntilChanged" />
       </Expression>
@@ -549,7 +541,6 @@ Item3 as Patch3)</scr:Expression>
         <LowPass>1</LowPass>
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\RepeatEveryBlock.bonsai" />
-      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RepeatEverySubject.bonsai" />
       <Expression xsi:type="rx:BehaviorSubject">
         <Name>Patch3TimeSpent</Name>
       </Expression>
@@ -557,7 +548,6 @@ Item3 as Patch3)</scr:Expression>
         <Name>Patch3TimeSpent</Name>
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\RepeatEveryBlock.bonsai" />
-      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RepeatEverySubject.bonsai" />
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:DistinctUntilChanged" />
       </Expression>
@@ -1368,153 +1358,143 @@ Value.TagId as TagId,
       <Edge From="29" To="30" Label="Source2" />
       <Edge From="30" To="31" Label="Source1" />
       <Edge From="31" To="32" Label="Source1" />
-      <Edge From="32" To="33" Label="Source1" />
-      <Edge From="34" To="35" Label="Source1" />
-      <Edge From="35" To="37" Label="Source1" />
-      <Edge From="36" To="37" Label="Source2" />
+      <Edge From="33" To="34" Label="Source1" />
+      <Edge From="34" To="36" Label="Source1" />
+      <Edge From="35" To="36" Label="Source2" />
+      <Edge From="36" To="37" Label="Source1" />
       <Edge From="37" To="38" Label="Source1" />
-      <Edge From="38" To="39" Label="Source1" />
       <Edge From="39" To="40" Label="Source1" />
-      <Edge From="41" To="42" Label="Source1" />
-      <Edge From="42" To="44" Label="Source1" />
-      <Edge From="43" To="44" Label="Source2" />
-      <Edge From="44" To="45" Label="Source1" />
+      <Edge From="40" To="42" Label="Source1" />
+      <Edge From="41" To="42" Label="Source2" />
+      <Edge From="42" To="43" Label="Source1" />
+      <Edge From="43" To="44" Label="Source1" />
       <Edge From="45" To="46" Label="Source1" />
       <Edge From="46" To="47" Label="Source1" />
-      <Edge From="48" To="49" Label="Source1" />
+      <Edge From="47" To="48" Label="Source1" />
       <Edge From="49" To="50" Label="Source1" />
       <Edge From="50" To="51" Label="Source1" />
-      <Edge From="52" To="53" Label="Source1" />
+      <Edge From="51" To="52" Label="Source1" />
       <Edge From="53" To="54" Label="Source1" />
       <Edge From="54" To="55" Label="Source1" />
-      <Edge From="56" To="57" Label="Source1" />
-      <Edge From="57" To="58" Label="Source1" />
-      <Edge From="58" To="59" Label="Source1" />
-      <Edge From="60" To="63" Label="Source1" />
-      <Edge From="61" To="63" Label="Source2" />
-      <Edge From="62" To="63" Label="Source3" />
-      <Edge From="63" To="64" Label="Source1" />
-      <Edge From="64" To="65" Label="Source1" />
-      <Edge From="65" To="66" Label="Source1" />
-      <Edge From="67" To="70" Label="Source1" />
-      <Edge From="68" To="70" Label="Source2" />
-      <Edge From="69" To="70" Label="Source3" />
-      <Edge From="70" To="71" Label="Source1" />
+      <Edge From="55" To="56" Label="Source1" />
+      <Edge From="57" To="60" Label="Source1" />
+      <Edge From="58" To="60" Label="Source2" />
+      <Edge From="59" To="60" Label="Source3" />
+      <Edge From="60" To="61" Label="Source1" />
+      <Edge From="61" To="62" Label="Source1" />
+      <Edge From="62" To="63" Label="Source1" />
+      <Edge From="64" To="67" Label="Source1" />
+      <Edge From="65" To="67" Label="Source2" />
+      <Edge From="66" To="67" Label="Source3" />
+      <Edge From="67" To="68" Label="Source1" />
+      <Edge From="68" To="69" Label="Source1" />
+      <Edge From="69" To="70" Label="Source1" />
       <Edge From="71" To="72" Label="Source1" />
       <Edge From="72" To="73" Label="Source1" />
+      <Edge From="73" To="80" Label="Source1" />
       <Edge From="74" To="75" Label="Source1" />
       <Edge From="75" To="76" Label="Source1" />
-      <Edge From="76" To="83" Label="Source1" />
+      <Edge From="76" To="80" Label="Source2" />
       <Edge From="77" To="78" Label="Source1" />
       <Edge From="78" To="79" Label="Source1" />
-      <Edge From="79" To="83" Label="Source2" />
+      <Edge From="79" To="80" Label="Source3" />
       <Edge From="80" To="81" Label="Source1" />
       <Edge From="81" To="82" Label="Source1" />
-      <Edge From="82" To="83" Label="Source3" />
+      <Edge From="82" To="83" Label="Source1" />
       <Edge From="83" To="84" Label="Source1" />
-      <Edge From="84" To="85" Label="Source1" />
       <Edge From="85" To="86" Label="Source1" />
       <Edge From="86" To="87" Label="Source1" />
-      <Edge From="87" To="88" Label="Source1" />
+      <Edge From="88" To="89" Label="Source1" />
       <Edge From="89" To="90" Label="Source1" />
       <Edge From="90" To="91" Label="Source1" />
       <Edge From="91" To="92" Label="Source1" />
       <Edge From="93" To="94" Label="Source1" />
       <Edge From="94" To="95" Label="Source1" />
-      <Edge From="95" To="96" Label="Source1" />
       <Edge From="96" To="97" Label="Source1" />
       <Edge From="97" To="98" Label="Source1" />
+      <Edge From="98" To="99" Label="Source1" />
       <Edge From="99" To="100" Label="Source1" />
-      <Edge From="100" To="101" Label="Source1" />
       <Edge From="101" To="102" Label="Source1" />
-      <Edge From="103" To="104" Label="Source1" />
+      <Edge From="102" To="103" Label="Source1" />
       <Edge From="104" To="105" Label="Source1" />
       <Edge From="105" To="106" Label="Source1" />
       <Edge From="106" To="107" Label="Source1" />
       <Edge From="107" To="108" Label="Source1" />
       <Edge From="109" To="110" Label="Source1" />
-      <Edge From="110" To="111" Label="Source1" />
       <Edge From="111" To="112" Label="Source1" />
+      <Edge From="112" To="113" Label="Source1" />
       <Edge From="113" To="114" Label="Source1" />
-      <Edge From="114" To="115" Label="Source1" />
+      <Edge From="114" To="117" Label="Source1" />
       <Edge From="115" To="116" Label="Source1" />
-      <Edge From="116" To="117" Label="Source1" />
+      <Edge From="116" To="117" Label="Source2" />
       <Edge From="117" To="118" Label="Source1" />
-      <Edge From="119" To="120" Label="Source1" />
+      <Edge From="118" To="119" Label="Source1" />
+      <Edge From="120" To="121" Label="Source1" />
       <Edge From="121" To="122" Label="Source1" />
       <Edge From="122" To="123" Label="Source1" />
       <Edge From="123" To="124" Label="Source1" />
-      <Edge From="124" To="127" Label="Source1" />
-      <Edge From="125" To="126" Label="Source1" />
-      <Edge From="126" To="127" Label="Source2" />
-      <Edge From="127" To="128" Label="Source1" />
+      <Edge From="125" To="128" Label="Source1" />
+      <Edge From="125" To="129" Label="Source2" />
+      <Edge From="126" To="128" Label="Source2" />
+      <Edge From="127" To="128" Label="Source3" />
       <Edge From="128" To="129" Label="Source1" />
+      <Edge From="129" To="130" Label="Source1" />
       <Edge From="130" To="131" Label="Source1" />
       <Edge From="131" To="132" Label="Source1" />
-      <Edge From="132" To="133" Label="Source1" />
-      <Edge From="133" To="134" Label="Source1" />
-      <Edge From="135" To="138" Label="Source1" />
-      <Edge From="135" To="139" Label="Source2" />
-      <Edge From="136" To="138" Label="Source2" />
-      <Edge From="137" To="138" Label="Source3" />
-      <Edge From="138" To="139" Label="Source1" />
+      <Edge From="133" To="135" Label="Source1" />
+      <Edge From="134" To="135" Label="Source2" />
+      <Edge From="135" To="139" Label="Source1" />
+      <Edge From="136" To="137" Label="Source1" />
+      <Edge From="137" To="138" Label="Source1" />
+      <Edge From="138" To="139" Label="Source2" />
       <Edge From="139" To="140" Label="Source1" />
       <Edge From="140" To="141" Label="Source1" />
-      <Edge From="141" To="142" Label="Source1" />
-      <Edge From="143" To="145" Label="Source1" />
-      <Edge From="144" To="145" Label="Source2" />
-      <Edge From="145" To="149" Label="Source1" />
+      <Edge From="142" To="143" Label="Source1" />
+      <Edge From="143" To="146" Label="Source1" />
+      <Edge From="144" To="145" Label="Source1" />
+      <Edge From="145" To="146" Label="Source2" />
       <Edge From="146" To="147" Label="Source1" />
       <Edge From="147" To="148" Label="Source1" />
-      <Edge From="148" To="149" Label="Source2" />
+      <Edge From="148" To="151" Label="Source1" />
       <Edge From="149" To="150" Label="Source1" />
-      <Edge From="150" To="151" Label="Source1" />
+      <Edge From="150" To="151" Label="Source2" />
+      <Edge From="151" To="152" Label="Source1" />
       <Edge From="152" To="153" Label="Source1" />
-      <Edge From="153" To="156" Label="Source1" />
-      <Edge From="154" To="155" Label="Source1" />
-      <Edge From="155" To="156" Label="Source2" />
+      <Edge From="153" To="154" Label="Source1" />
+      <Edge From="155" To="158" Label="Source1" />
       <Edge From="156" To="157" Label="Source1" />
-      <Edge From="157" To="158" Label="Source1" />
-      <Edge From="158" To="161" Label="Source1" />
+      <Edge From="157" To="158" Label="Source2" />
+      <Edge From="158" To="159" Label="Source1" />
       <Edge From="159" To="160" Label="Source1" />
-      <Edge From="160" To="161" Label="Source2" />
       <Edge From="161" To="162" Label="Source1" />
-      <Edge From="162" To="163" Label="Source1" />
       <Edge From="163" To="164" Label="Source1" />
-      <Edge From="165" To="168" Label="Source1" />
-      <Edge From="166" To="167" Label="Source1" />
-      <Edge From="167" To="168" Label="Source2" />
+      <Edge From="165" To="166" Label="Source1" />
+      <Edge From="167" To="168" Label="Source1" />
       <Edge From="168" To="169" Label="Source1" />
-      <Edge From="169" To="170" Label="Source1" />
+      <Edge From="170" To="171" Label="Source1" />
       <Edge From="171" To="172" Label="Source1" />
       <Edge From="173" To="174" Label="Source1" />
-      <Edge From="175" To="176" Label="Source1" />
+      <Edge From="174" To="175" Label="Source1" />
+      <Edge From="176" To="177" Label="Source1" />
       <Edge From="177" To="178" Label="Source1" />
-      <Edge From="178" To="179" Label="Source1" />
+      <Edge From="179" To="180" Label="Source1" />
       <Edge From="180" To="181" Label="Source1" />
-      <Edge From="181" To="182" Label="Source1" />
+      <Edge From="182" To="183" Label="Source1" />
       <Edge From="183" To="184" Label="Source1" />
-      <Edge From="184" To="185" Label="Source1" />
-      <Edge From="186" To="187" Label="Source1" />
+      <Edge From="185" To="186" Label="Source1" />
+      <Edge From="186" To="197" Label="Source1" />
       <Edge From="187" To="188" Label="Source1" />
+      <Edge From="188" To="197" Label="Source2" />
       <Edge From="189" To="190" Label="Source1" />
-      <Edge From="190" To="191" Label="Source1" />
-      <Edge From="192" To="193" Label="Source1" />
+      <Edge From="190" To="197" Label="Source3" />
+      <Edge From="191" To="192" Label="Source1" />
+      <Edge From="192" To="197" Label="Source4" />
       <Edge From="193" To="194" Label="Source1" />
+      <Edge From="194" To="197" Label="Source5" />
       <Edge From="195" To="196" Label="Source1" />
-      <Edge From="196" To="207" Label="Source1" />
+      <Edge From="196" To="197" Label="Source6" />
       <Edge From="197" To="198" Label="Source1" />
-      <Edge From="198" To="207" Label="Source2" />
-      <Edge From="199" To="200" Label="Source1" />
-      <Edge From="200" To="207" Label="Source3" />
-      <Edge From="201" To="202" Label="Source1" />
-      <Edge From="202" To="207" Label="Source4" />
-      <Edge From="203" To="204" Label="Source1" />
-      <Edge From="204" To="207" Label="Source5" />
-      <Edge From="205" To="206" Label="Source1" />
-      <Edge From="206" To="207" Label="Source6" />
-      <Edge From="207" To="208" Label="Source1" />
-      <Edge From="208" To="209" Label="Source1" />
+      <Edge From="198" To="199" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
This PR removes the forced reset of environment logic and visualizers when the subject list is modified. The environment logic will not change now unless an explicit reload environment is issued.