### PR TITLE
Remove unused debugging log

### DIFF
--- a/workflows/social/Extensions/Alerts.bonsai
+++ b/workflows/social/Extensions/Alerts.bonsai
@@ -1715,16 +1715,6 @@ Item2.GetTimestamp() as Timestamp)</scr:Expression>
             <Expression xsi:type="MulticastSubject">
               <Name>AlertLogs</Name>
             </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Timestamp" />
-            </Expression>
-            <Expression xsi:type="io:CsvWriter">
-              <io:FileName>D:\TimestampClockSyncHeartBeat\TimestampClockSyncHeartBeat.csv</io:FileName>
-              <io:Append>true</io:Append>
-              <io:Overwrite>false</io:Overwrite>
-              <io:Suffix>None</io:Suffix>
-              <io:IncludeHeader>true</io:IncludeHeader>
-            </Expression>
           </Nodes>
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
@@ -1770,13 +1760,11 @@ Item2.GetTimestamp() as Timestamp)</scr:Expression>
             <Edge From="46" To="47" Label="Source1" />
             <Edge From="48" To="49" Label="Source1" />
             <Edge From="49" To="50" Label="Source1" />
-            <Edge From="49" To="56" Label="Source1" />
             <Edge From="50" To="51" Label="Source1" />
             <Edge From="51" To="52" Label="Source1" />
             <Edge From="51" To="54" Label="Source1" />
             <Edge From="52" To="53" Label="Source1" />
             <Edge From="54" To="55" Label="Source1" />
-            <Edge From="56" To="57" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>


### PR DESCRIPTION
This PR removes an unused debugging log which was used originally to monitor heartbeat synchronization behavior, as we do not use these logs anymore. If required again, we should add an explicit QC stream to the dataset.