### PR TITLE
Add video stream selector to main control panel

### DIFF
--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Aeon.Acquisition" version="0.5.0-build240101" />
+    <Package id="Aeon.Acquisition" version="0.5.0-build240102" />
     <Package id="Aeon.Database" version="0.1.0-build231020" />
-    <Package id="Aeon.Environment" version="0.1.0-build240101" />
+    <Package id="Aeon.Environment" version="0.1.0-build240102" />
     <Package id="Aeon.Foraging" version="0.1.0-build231202" />
     <Package id="AsyncIO" version="0.1.69" />
     <Package id="Bonsai" version="2.8.1" />
@@ -109,9 +109,9 @@
     <AssemblyReference assemblyName="Harp.TimestampGeneratorGen3" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Aeon.Acquisition" processorArchitecture="MSIL" location="Packages\Aeon.Acquisition.0.5.0-build240101\lib\net472\Aeon.Acquisition.dll" />
+    <AssemblyLocation assemblyName="Aeon.Acquisition" processorArchitecture="MSIL" location="Packages\Aeon.Acquisition.0.5.0-build240102\lib\net472\Aeon.Acquisition.dll" />
     <AssemblyLocation assemblyName="Aeon.Database" processorArchitecture="MSIL" location="Packages\Aeon.Database.0.1.0-build231020\lib\net472\Aeon.Database.dll" />
-    <AssemblyLocation assemblyName="Aeon.Environment" processorArchitecture="MSIL" location="Packages\Aeon.Environment.0.1.0-build240101\lib\net472\Aeon.Environment.dll" />
+    <AssemblyLocation assemblyName="Aeon.Environment" processorArchitecture="MSIL" location="Packages\Aeon.Environment.0.1.0-build240102\lib\net472\Aeon.Environment.dll" />
     <AssemblyLocation assemblyName="Aeon.Foraging" processorArchitecture="MSIL" location="Packages\Aeon.Foraging.0.1.0-build231202\lib\net472\Aeon.Foraging.dll" />
     <AssemblyLocation assemblyName="AsyncIO" processorArchitecture="MSIL" location="Packages\AsyncIO.0.1.69\lib\net40\AsyncIO.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="X86" location="Packages\Bonsai.Pylon.0.3.0\build\net462\bin\x86\Basler.Pylon.dll" />

--- a/workflows/social/Extensions/ControlPanel.bonsai
+++ b/workflows/social/Extensions/ControlPanel.bonsai
@@ -1101,23 +1101,109 @@ FilteredWeight.Value - BaselinedWeight.Value as Baseline)</scr:Expression>
           </Edges>
         </Workflow>
       </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="SelectedStream" />
+      </Expression>
       <Expression xsi:type="GroupWorkflow">
-        <Name>OverheadCamera</Name>
+        <Name>CameraSelector</Name>
         <Workflow>
           <Nodes>
             <Expression xsi:type="SubscribeSubject">
-              <Name>Trajectory</Name>
+              <Name>CameraTop</Name>
             </Expression>
-            <Expression xsi:type="VisualizerMapping" />
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value.Image</Selector>
+            </Expression>
             <Expression xsi:type="SubscribeSubject">
-              <Name>FrameTrajectory</Name>
+              <Name>CameraWest</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value.Image</Selector>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>CameraEast</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value.Image</Selector>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>CameraNorth</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value.Image</Selector>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>CameraSouth</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value.Image</Selector>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>CameraNest</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value.Image</Selector>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>CameraPatch1</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value.Image</Selector>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>CameraPatch2</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value.Image</Selector>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>CameraPatch3</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value.Image</Selector>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="SelectedStream" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="p1:StreamSelector">
+                <p1:SelectedStream>CameraTop</p1:SelectedStream>
+                <p1:StreamNames>
+                  <p1:string>CameraTop</p1:string>
+                  <p1:string>CameraWest</p1:string>
+                  <p1:string>CameraEast</p1:string>
+                  <p1:string>CameraNorth</p1:string>
+                  <p1:string>CameraSouth</p1:string>
+                  <p1:string>CameraNest</p1:string>
+                  <p1:string>CameraPatch1</p1:string>
+                  <p1:string>CameraPatch2</p1:string>
+                  <p1:string>CameraPatch3</p1:string>
+                </p1:StreamNames>
+              </Combinator>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
           </Nodes>
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
-            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="1" To="19" Label="Source1" />
             <Edge From="2" To="3" Label="Source1" />
+            <Edge From="3" To="19" Label="Source2" />
+            <Edge From="4" To="5" Label="Source1" />
+            <Edge From="5" To="19" Label="Source3" />
+            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="7" To="19" Label="Source4" />
+            <Edge From="8" To="9" Label="Source1" />
+            <Edge From="9" To="19" Label="Source5" />
+            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="11" To="19" Label="Source6" />
+            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="13" To="19" Label="Source7" />
+            <Edge From="14" To="15" Label="Source1" />
+            <Edge From="15" To="19" Label="Source8" />
+            <Edge From="16" To="17" Label="Source1" />
+            <Edge From="17" To="19" Label="Source9" />
+            <Edge From="18" To="19" Label="Source10" />
+            <Edge From="19" To="20" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
@@ -1129,6 +1215,7 @@ FilteredWeight.Value - BaselinedWeight.Value as Baseline)</scr:Expression>
       <Edge From="3" To="4" Label="Source1" />
       <Edge From="5" To="6" Label="Source1" />
       <Edge From="7" To="8" Label="Source1" />
+      <Edge From="13" To="14" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/workflows/social/Extensions/StreamSelector.cs
+++ b/workflows/social/Extensions/StreamSelector.cs
@@ -1,0 +1,61 @@
+using Bonsai;
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Collections.ObjectModel;
+using Bonsai.Expressions;
+
+[Combinator]
+[Description("Selects a specific stream by name from a set of input streams.")]
+[WorkflowElementCategory(ElementCategory.Combinator)]
+[DefaultProperty("StreamNames")]
+public class StreamSelector
+{
+    readonly Collection<string> streamNames = new Collection<string>();
+
+    [TypeConverter(typeof(SelectedStreamConverter))]
+    public string SelectedStream { get; set; }
+
+    public Collection<string> StreamNames
+    {
+        get { return streamNames; }
+    }
+
+    public IObservable<TSource> Process<TSource>(params IObservable<TSource>[] source)
+    {
+        var filteredStreams = new IObservable<TSource>[source.Length];
+        for (int i = 0; i < source.Length; i++)
+        {
+            var name = i < streamNames.Count ? streamNames[i] : string.Empty;
+            filteredStreams[i] = source[i].Where(_ => name == SelectedStream);
+        }
+
+        return Observable.Merge(filteredStreams);
+    }
+
+    class SelectedStreamConverter : StringConverter
+    {
+        public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+        {
+            return true;
+        }
+
+        public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+        {
+            StreamSelector selector = null;
+            var workflowBuilder = (WorkflowBuilder)context.GetService(typeof(WorkflowBuilder));
+            var descendants = workflowBuilder.Workflow.Descendants();
+            foreach (var node in descendants)
+            {
+                selector = ExpressionBuilder.GetWorkflowElement(node) as StreamSelector;
+                if (selector != null)
+                {
+                    break;
+                }
+            }
+
+            return new StandardValuesCollection(selector.StreamNames);
+        }
+    }
+}

--- a/workflows/social/Social-AEON3.bonsai
+++ b/workflows/social/Social-AEON3.bonsai
@@ -961,7 +961,12 @@
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\Logging.bonsai">
         <WorkflowName>Social-AEON3.bonsai</WorkflowName>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Extensions\ControlPanel.bonsai" />
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="SelectedStream" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Extensions\ControlPanel.bonsai">
+        <SelectedStream>CameraTop</SelectedStream>
+      </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="EnvironmentConfigPath" />
       </Expression>
@@ -979,8 +984,9 @@
       </Expression>
     </Nodes>
     <Edges>
-      <Edge From="6" To="7" Label="Source1" />
-      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/workflows/social/Social-AEON3.bonsai.layout
+++ b/workflows/social/Social-AEON3.bonsai.layout
@@ -1852,6 +1852,18 @@
       </DialogSettings>
     </EditorVisualizerLayout>
   </DialogSettings>
+  <DialogSettings>
+    <Visible>false</Visible>
+    <Location>
+      <X>0</X>
+      <Y>0</Y>
+    </Location>
+    <Size>
+      <Width>0</Width>
+      <Height>0</Height>
+    </Size>
+    <WindowState>Normal</WindowState>
+  </DialogSettings>
   <DialogSettings xsi:type="WorkflowEditorSettings">
     <Visible>false</Visible>
     <Location>
@@ -2038,8 +2050,8 @@
                       <MatVisualizer>
                         <XMin>0</XMin>
                         <XMax>1500</XMax>
-                        <YMin>-20</YMin>
-                        <YMax>160</YMax>
+                        <YMin>0</YMin>
+                        <YMax>600</YMax>
                         <AutoScaleX>true</AutoScaleX>
                         <AutoScaleY>true</AutoScaleY>
                         <SelectedPage>0</SelectedPage>
@@ -2057,8 +2069,8 @@
                       <MatVisualizer>
                         <XMin>0</XMin>
                         <XMax>1500</XMax>
-                        <YMin>-20</YMin>
-                        <YMax>160</YMax>
+                        <YMin>0</YMin>
+                        <YMax>300</YMax>
                         <AutoScaleX>true</AutoScaleX>
                         <AutoScaleY>true</AutoScaleY>
                         <SelectedPage>0</SelectedPage>
@@ -2076,8 +2088,8 @@
                       <MatVisualizer>
                         <XMin>0</XMin>
                         <XMax>1500</XMax>
-                        <YMin>-50</YMin>
-                        <YMax>350</YMax>
+                        <YMin>0</YMin>
+                        <YMax>249.99999999999997</YMax>
                         <AutoScaleX>true</AutoScaleX>
                         <AutoScaleY>true</AutoScaleY>
                         <SelectedPage>0</SelectedPage>
@@ -2094,8 +2106,8 @@
                     <VisualizerSettings>
                       <RollingGraphVisualizer>
                         <Capacity>0</Capacity>
-                        <Min>126</Min>
-                        <Max>142</Max>
+                        <Min>530</Min>
+                        <Max>600</Max>
                         <AutoScale>true</AutoScale>
                       </RollingGraphVisualizer>
                     </VisualizerSettings>
@@ -2105,8 +2117,8 @@
                     <VisualizerSettings>
                       <RollingGraphVisualizer>
                         <Capacity>0</Capacity>
-                        <Min>132</Min>
-                        <Max>148</Max>
+                        <Min>240</Min>
+                        <Max>270</Max>
                         <AutoScale>true</AutoScale>
                       </RollingGraphVisualizer>
                     </VisualizerSettings>
@@ -2116,8 +2128,8 @@
                     <VisualizerSettings>
                       <RollingGraphVisualizer>
                         <Capacity>0</Capacity>
-                        <Min>290</Min>
-                        <Max>330</Max>
+                        <Min>220</Min>
+                        <Max>245</Max>
                         <AutoScale>true</AutoScale>
                       </RollingGraphVisualizer>
                     </VisualizerSettings>
@@ -2173,14 +2185,9 @@
                     </VisualizerSettings>
                   </MashupSettings>
                   <MashupSettings>
-                    <VisualizerTypeName>Bonsai.Design.Visualizers.BarGraphVisualizer</VisualizerTypeName>
+                    <VisualizerTypeName>RfidMeasurementVisualizer</VisualizerTypeName>
                     <VisualizerSettings>
-                      <BarGraphVisualizer>
-                        <Capacity>0</Capacity>
-                        <Min>-1</Min>
-                        <Max>1</Max>
-                        <AutoScale>true</AutoScale>
-                      </BarGraphVisualizer>
+                      <RfidMeasurementVisualizer />
                     </VisualizerSettings>
                   </MashupSettings>
                   <MashupSettings>
@@ -2189,7 +2196,7 @@
                       <BarGraphVisualizer>
                         <Capacity>0</Capacity>
                         <Min>0</Min>
-                        <Max>100</Max>
+                        <Max>1.1</Max>
                         <AutoScale>true</AutoScale>
                       </BarGraphVisualizer>
                     </VisualizerSettings>
@@ -2199,8 +2206,8 @@
                     <VisualizerSettings>
                       <BarGraphVisualizer>
                         <Capacity>0</Capacity>
-                        <Min>-0.004</Min>
-                        <Max>0.005</Max>
+                        <Min>-0.0035000000000000005</Min>
+                        <Max>0</Max>
                         <AutoScale>true</AutoScale>
                       </BarGraphVisualizer>
                     </VisualizerSettings>
@@ -2244,11 +2251,11 @@
               </VisualizerSettings>
             </MashupSettings>
             <MashupSettings>
-              <VisualizerTypeName>Bonsai.Sleap.Design.PoseIdentityCollectionVisualizer</VisualizerTypeName>
+              <VisualizerTypeName>ActiveSubjectVisualizer</VisualizerTypeName>
               <VisualizerSettings>
-                <PoseIdentityCollectionVisualizer>
+                <ActiveSubjectVisualizer>
                   <DrawIdentity>false</DrawIdentity>
-                </PoseIdentityCollectionVisualizer>
+                </ActiveSubjectVisualizer>
               </VisualizerSettings>
             </MashupSettings>
             <MashupSettings>
@@ -2358,14 +2365,9 @@
               </VisualizerSettings>
             </MashupSettings>
             <MashupSettings>
-              <VisualizerTypeName>Bonsai.Design.Visualizers.RollingGraphVisualizer</VisualizerTypeName>
+              <VisualizerTypeName>LabeledSeriesVisualizer</VisualizerTypeName>
               <VisualizerSettings>
-                <RollingGraphVisualizer>
-                  <Capacity>0</Capacity>
-                  <Min>0</Min>
-                  <Max>1.1</Max>
-                  <AutoScale>true</AutoScale>
-                </RollingGraphVisualizer>
+                <LabeledSeriesVisualizer />
               </VisualizerSettings>
             </MashupSettings>
             <MashupSettings>
@@ -2373,8 +2375,8 @@
               <VisualizerSettings>
                 <RollingGraphVisualizer>
                   <Capacity>640</Capacity>
-                  <Min>-1</Min>
-                  <Max>1</Max>
+                  <Min>0</Min>
+                  <Max>1.1</Max>
                   <AutoScale>true</AutoScale>
                 </RollingGraphVisualizer>
               </VisualizerSettings>
@@ -2418,6 +2420,22 @@
               </VisualizerSettings>
             </MashupSettings>
           </IplImageVisualizer>
+        </VisualizerSettings>
+      </DialogSettings>
+      <DialogSettings>
+        <Visible>true</Visible>
+        <Location>
+          <X>1643</X>
+          <Y>10</Y>
+        </Location>
+        <Size>
+          <Width>249</Width>
+          <Height>207</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+        <VisualizerTypeName>Bonsai.Vision.Design.IplImageVisualizer</VisualizerTypeName>
+        <VisualizerSettings>
+          <IplImageVisualizer />
         </VisualizerSettings>
       </DialogSettings>
     </EditorVisualizerLayout>

--- a/workflows/social/Social-AEON4.bonsai
+++ b/workflows/social/Social-AEON4.bonsai
@@ -1013,7 +1013,12 @@
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\Logging.bonsai">
         <WorkflowName>Social-AEON4.bonsai</WorkflowName>
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Extensions\ControlPanel.bonsai" />
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="SelectedStream" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Extensions\ControlPanel.bonsai">
+        <SelectedStream>CameraTop</SelectedStream>
+      </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="EnvironmentConfigPath" />
       </Expression>
@@ -1022,7 +1027,8 @@
       </Expression>
     </Nodes>
     <Edges>
-      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/workflows/social/Social-AEON4.bonsai.layout
+++ b/workflows/social/Social-AEON4.bonsai.layout
@@ -1852,6 +1852,18 @@
       </DialogSettings>
     </EditorVisualizerLayout>
   </DialogSettings>
+  <DialogSettings>
+    <Visible>false</Visible>
+    <Location>
+      <X>0</X>
+      <Y>0</Y>
+    </Location>
+    <Size>
+      <Width>0</Width>
+      <Height>0</Height>
+    </Size>
+    <WindowState>Normal</WindowState>
+  </DialogSettings>
   <DialogSettings xsi:type="WorkflowEditorSettings">
     <Visible>false</Visible>
     <Location>
@@ -2038,8 +2050,8 @@
                       <MatVisualizer>
                         <XMin>0</XMin>
                         <XMax>1500</XMax>
-                        <YMin>-20</YMin>
-                        <YMax>160</YMax>
+                        <YMin>0</YMin>
+                        <YMax>600</YMax>
                         <AutoScaleX>true</AutoScaleX>
                         <AutoScaleY>true</AutoScaleY>
                         <SelectedPage>0</SelectedPage>
@@ -2057,8 +2069,8 @@
                       <MatVisualizer>
                         <XMin>0</XMin>
                         <XMax>1500</XMax>
-                        <YMin>-20</YMin>
-                        <YMax>160</YMax>
+                        <YMin>0</YMin>
+                        <YMax>300</YMax>
                         <AutoScaleX>true</AutoScaleX>
                         <AutoScaleY>true</AutoScaleY>
                         <SelectedPage>0</SelectedPage>
@@ -2076,8 +2088,8 @@
                       <MatVisualizer>
                         <XMin>0</XMin>
                         <XMax>1500</XMax>
-                        <YMin>-50</YMin>
-                        <YMax>350</YMax>
+                        <YMin>0</YMin>
+                        <YMax>249.99999999999997</YMax>
                         <AutoScaleX>true</AutoScaleX>
                         <AutoScaleY>true</AutoScaleY>
                         <SelectedPage>0</SelectedPage>
@@ -2094,8 +2106,8 @@
                     <VisualizerSettings>
                       <RollingGraphVisualizer>
                         <Capacity>0</Capacity>
-                        <Min>126</Min>
-                        <Max>142</Max>
+                        <Min>530</Min>
+                        <Max>600</Max>
                         <AutoScale>true</AutoScale>
                       </RollingGraphVisualizer>
                     </VisualizerSettings>
@@ -2105,8 +2117,8 @@
                     <VisualizerSettings>
                       <RollingGraphVisualizer>
                         <Capacity>0</Capacity>
-                        <Min>132</Min>
-                        <Max>148</Max>
+                        <Min>240</Min>
+                        <Max>270</Max>
                         <AutoScale>true</AutoScale>
                       </RollingGraphVisualizer>
                     </VisualizerSettings>
@@ -2116,8 +2128,8 @@
                     <VisualizerSettings>
                       <RollingGraphVisualizer>
                         <Capacity>0</Capacity>
-                        <Min>290</Min>
-                        <Max>330</Max>
+                        <Min>220</Min>
+                        <Max>245</Max>
                         <AutoScale>true</AutoScale>
                       </RollingGraphVisualizer>
                     </VisualizerSettings>
@@ -2173,14 +2185,9 @@
                     </VisualizerSettings>
                   </MashupSettings>
                   <MashupSettings>
-                    <VisualizerTypeName>Bonsai.Design.Visualizers.BarGraphVisualizer</VisualizerTypeName>
+                    <VisualizerTypeName>RfidMeasurementVisualizer</VisualizerTypeName>
                     <VisualizerSettings>
-                      <BarGraphVisualizer>
-                        <Capacity>0</Capacity>
-                        <Min>-1</Min>
-                        <Max>1</Max>
-                        <AutoScale>true</AutoScale>
-                      </BarGraphVisualizer>
+                      <RfidMeasurementVisualizer />
                     </VisualizerSettings>
                   </MashupSettings>
                   <MashupSettings>
@@ -2189,7 +2196,7 @@
                       <BarGraphVisualizer>
                         <Capacity>0</Capacity>
                         <Min>0</Min>
-                        <Max>100</Max>
+                        <Max>1.1</Max>
                         <AutoScale>true</AutoScale>
                       </BarGraphVisualizer>
                     </VisualizerSettings>
@@ -2199,8 +2206,8 @@
                     <VisualizerSettings>
                       <BarGraphVisualizer>
                         <Capacity>0</Capacity>
-                        <Min>-0.004</Min>
-                        <Max>0.005</Max>
+                        <Min>-0.0035000000000000005</Min>
+                        <Max>0</Max>
                         <AutoScale>true</AutoScale>
                       </BarGraphVisualizer>
                     </VisualizerSettings>
@@ -2244,11 +2251,11 @@
               </VisualizerSettings>
             </MashupSettings>
             <MashupSettings>
-              <VisualizerTypeName>Bonsai.Sleap.Design.PoseIdentityCollectionVisualizer</VisualizerTypeName>
+              <VisualizerTypeName>ActiveSubjectVisualizer</VisualizerTypeName>
               <VisualizerSettings>
-                <PoseIdentityCollectionVisualizer>
+                <ActiveSubjectVisualizer>
                   <DrawIdentity>false</DrawIdentity>
-                </PoseIdentityCollectionVisualizer>
+                </ActiveSubjectVisualizer>
               </VisualizerSettings>
             </MashupSettings>
             <MashupSettings>
@@ -2358,14 +2365,9 @@
               </VisualizerSettings>
             </MashupSettings>
             <MashupSettings>
-              <VisualizerTypeName>Bonsai.Design.Visualizers.RollingGraphVisualizer</VisualizerTypeName>
+              <VisualizerTypeName>LabeledSeriesVisualizer</VisualizerTypeName>
               <VisualizerSettings>
-                <RollingGraphVisualizer>
-                  <Capacity>0</Capacity>
-                  <Min>0</Min>
-                  <Max>1.1</Max>
-                  <AutoScale>true</AutoScale>
-                </RollingGraphVisualizer>
+                <LabeledSeriesVisualizer />
               </VisualizerSettings>
             </MashupSettings>
             <MashupSettings>
@@ -2373,8 +2375,8 @@
               <VisualizerSettings>
                 <RollingGraphVisualizer>
                   <Capacity>640</Capacity>
-                  <Min>-1</Min>
-                  <Max>1</Max>
+                  <Min>0</Min>
+                  <Max>1.1</Max>
                   <AutoScale>true</AutoScale>
                 </RollingGraphVisualizer>
               </VisualizerSettings>
@@ -2420,6 +2422,22 @@
           </IplImageVisualizer>
         </VisualizerSettings>
       </DialogSettings>
+      <DialogSettings>
+        <Visible>true</Visible>
+        <Location>
+          <X>1643</X>
+          <Y>10</Y>
+        </Location>
+        <Size>
+          <Width>249</Width>
+          <Height>207</Height>
+        </Size>
+        <WindowState>Normal</WindowState>
+        <VisualizerTypeName>Bonsai.Vision.Design.IplImageVisualizer</VisualizerTypeName>
+        <VisualizerSettings>
+          <IplImageVisualizer />
+        </VisualizerSettings>
+      </DialogSettings>
     </EditorVisualizerLayout>
   </DialogSettings>
   <DialogSettings>
@@ -2457,5 +2475,29 @@
       </Size>
       <WindowState>Normal</WindowState>
     </EditorDialogSettings>
+  </DialogSettings>
+  <DialogSettings>
+    <Visible>false</Visible>
+    <Location>
+      <X>0</X>
+      <Y>0</Y>
+    </Location>
+    <Size>
+      <Width>0</Width>
+      <Height>0</Height>
+    </Size>
+    <WindowState>Normal</WindowState>
+  </DialogSettings>
+  <DialogSettings>
+    <Visible>false</Visible>
+    <Location>
+      <X>0</X>
+      <Y>0</Y>
+    </Location>
+    <Size>
+      <Width>0</Width>
+      <Height>0</Height>
+    </Size>
+    <WindowState>Normal</WindowState>
   </DialogSettings>
 </VisualizerLayout>

--- a/workflows/social/Social-Simulator.bonsai
+++ b/workflows/social/Social-Simulator.bonsai
@@ -131,6 +131,121 @@
                     </Workflow>
                   </Expression>
                   <Expression xsi:type="GroupWorkflow">
+                    <Name>CameraWest</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="TriggerSource" />
+                          <Property Name="FrameEvents" />
+                          <Property Name="TriggerFrequency" />
+                        </Expression>
+                        <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:FileVideoSource.bonsai">
+                          <TriggerSource>GlobalTrigger</TriggerSource>
+                          <FileName>Config\ArenaMask-AEON3_2023-11-10.png</FileName>
+                          <FrameEvents>CameraWest</FrameEvents>
+                          <TriggerFrequency>GlobalTriggerFrequency</TriggerFrequency>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
+                    <Name>CameraEast</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="TriggerSource" />
+                          <Property Name="FrameEvents" />
+                          <Property Name="TriggerFrequency" />
+                        </Expression>
+                        <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:FileVideoSource.bonsai">
+                          <TriggerSource>GlobalTrigger</TriggerSource>
+                          <FileName>Config\ArenaMask-AEON3_2023-11-10.png</FileName>
+                          <FrameEvents>CameraEast</FrameEvents>
+                          <TriggerFrequency>GlobalTriggerFrequency</TriggerFrequency>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
+                    <Name>CameraNorth</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="TriggerSource" />
+                          <Property Name="FrameEvents" />
+                          <Property Name="TriggerFrequency" />
+                        </Expression>
+                        <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:FileVideoSource.bonsai">
+                          <TriggerSource>GlobalTrigger</TriggerSource>
+                          <FileName>Config\ArenaMask-AEON3_2023-11-10.png</FileName>
+                          <FrameEvents>CameraNorth</FrameEvents>
+                          <TriggerFrequency>GlobalTriggerFrequency</TriggerFrequency>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
+                    <Name>CameraSouth</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="TriggerSource" />
+                          <Property Name="FrameEvents" />
+                          <Property Name="TriggerFrequency" />
+                        </Expression>
+                        <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:FileVideoSource.bonsai">
+                          <TriggerSource>GlobalTrigger</TriggerSource>
+                          <FileName>Config\ArenaMask-AEON3_2023-11-10.png</FileName>
+                          <FrameEvents>CameraSouth</FrameEvents>
+                          <TriggerFrequency>GlobalTriggerFrequency</TriggerFrequency>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
+                    <Name>CameraNest</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="TriggerSource" />
+                          <Property Name="FrameEvents" />
+                          <Property Name="TriggerFrequency" />
+                        </Expression>
+                        <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:FileVideoSource.bonsai">
+                          <TriggerSource>GlobalTrigger</TriggerSource>
+                          <FileName>Config\ArenaMask-AEON3_2023-11-10.png</FileName>
+                          <FrameEvents>CameraNest</FrameEvents>
+                          <TriggerFrequency>GlobalTriggerFrequency</TriggerFrequency>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
                     <Name>CameraPatch1</Name>
                     <Workflow>
                       <Nodes>
@@ -438,7 +553,9 @@
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\Declarations.bonsai" />
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\Visualization.bonsai" />
-      <Expression xsi:type="IncludeWorkflow" Path="Extensions\ControlPanel.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Extensions\ControlPanel.bonsai">
+        <SelectedStream>CameraTop</SelectedStream>
+      </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="EnvironmentConfigPath" />
       </Expression>


### PR DESCRIPTION
This PR adds a new stream selector to the main control panel allowing dynamically picking which camera is displayed in the floating visualizer window. The aim is to provide a way to quickly inspect the status of every camera in a floating window which can be expanded on demand.

Fixes #494 