### PR TITLE
Update harp package to avoid serial port hanging

### DIFF
--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -14,7 +14,7 @@
     <Package id="Bonsai.Dsp" version="2.8.0" />
     <Package id="Bonsai.Dsp.Design" version="2.8.0" />
     <Package id="Bonsai.Editor" version="2.8.0" />
-    <Package id="Bonsai.Harp" version="3.5.0" />
+    <Package id="Bonsai.Harp" version="3.5.2" />
     <Package id="Bonsai.Harp.Design" version="3.5.0" />
     <Package id="Bonsai.Numerics" version="0.9.0" />
     <Package id="Bonsai.Osc" version="2.7.0" />
@@ -124,7 +124,7 @@
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.2.8.0\lib\net462\Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.Design.2.8.0\lib\net462\Bonsai.Dsp.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.0\lib\net472\Bonsai.Editor.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Harp" processorArchitecture="MSIL" location="Packages\Bonsai.Harp.3.5.0\lib\net462\Bonsai.Harp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Harp" processorArchitecture="MSIL" location="Packages\Bonsai.Harp.3.5.2\lib\net462\Bonsai.Harp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Harp.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Harp.Design.3.5.0\lib\net462\Bonsai.Harp.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages\Bonsai.Numerics.0.9.0\lib\net462\Bonsai.Numerics.dll" />
     <AssemblyLocation assemblyName="Bonsai.Osc" processorArchitecture="MSIL" location="Packages\Bonsai.Osc.2.7.0\lib\net462\Bonsai.Osc.dll" />


### PR DESCRIPTION
This PR updates the Harp package to ensure the serial transport is closed on shutdown errors as described in https://github.com/bonsai-rx/harp/pull/84.