### PR TITLE
Add twist correction to commutator controller

### DIFF
--- a/workflows/ephys/Extensions/CommutatorController.bonsai
+++ b/workflows/ephys/Extensions/CommutatorController.bonsai
@@ -3,8 +3,8 @@
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:wie="clr-namespace:Bonsai.Windows.Input;assembly=Bonsai.Windows.Input"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
-                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns:p1="clr-namespace:;assembly=Extensions"
+                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns:port="clr-namespace:Bonsai.IO.Ports;assembly=Bonsai.System"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Description>Drives the turns of an ONIX rotary commutator.</Description>
@@ -73,6 +73,15 @@
             <Expression xsi:type="MemberSelector">
               <Selector>Quaternion</Selector>
             </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="p1:GetQuaternionTwist">
+                <p1:Direction>
+                  <p1:X>0</p1:X>
+                  <p1:Y>0</p1:Y>
+                  <p1:Z>1</p1:Z>
+                </p1:Direction>
+              </Combinator>
+            </Expression>
             <Expression xsi:type="scr:ExpressionTransform">
               <scr:Name>Heading</scr:Name>
               <scr:Expression>Math.Atan2((2 * (W * Z + X * Y)), (1 - 2 * (Y * Y + Z * Z)))</scr:Expression>
@@ -116,28 +125,29 @@
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
             <Edge From="1" To="2" Label="Source1" />
-            <Edge From="2" To="21" Label="Source1" />
+            <Edge From="2" To="22" Label="Source1" />
             <Edge From="3" To="4" Label="Source1" />
             <Edge From="4" To="5" Label="Source1" />
-            <Edge From="5" To="21" Label="Source2" />
+            <Edge From="5" To="22" Label="Source2" />
             <Edge From="6" To="9" Label="Source1" />
             <Edge From="7" To="8" Label="Source1" />
             <Edge From="8" To="9" Label="Source2" />
             <Edge From="9" To="10" Label="Source1" />
-            <Edge From="9" To="15" Label="Source1" />
+            <Edge From="9" To="16" Label="Source1" />
             <Edge From="10" To="11" Label="Source1" />
             <Edge From="11" To="12" Label="Source1" />
-            <Edge From="11" To="13" Label="Source1" />
-            <Edge From="12" To="13" Label="Source2" />
-            <Edge From="13" To="14" Label="Source1" />
-            <Edge From="14" To="17" Label="Source1" />
-            <Edge From="15" To="16" Label="Source1" />
-            <Edge From="16" To="17" Label="Source2" />
-            <Edge From="17" To="19" Label="Source1" />
-            <Edge From="18" To="19" Label="Source2" />
-            <Edge From="19" To="20" Label="Source1" />
-            <Edge From="20" To="21" Label="Source3" />
-            <Edge From="21" To="22" Label="Source1" />
+            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="12" To="14" Label="Source1" />
+            <Edge From="13" To="14" Label="Source2" />
+            <Edge From="14" To="15" Label="Source1" />
+            <Edge From="15" To="18" Label="Source1" />
+            <Edge From="16" To="17" Label="Source1" />
+            <Edge From="17" To="18" Label="Source2" />
+            <Edge From="18" To="20" Label="Source1" />
+            <Edge From="19" To="20" Label="Source2" />
+            <Edge From="20" To="21" Label="Source1" />
+            <Edge From="21" To="22" Label="Source3" />
+            <Edge From="22" To="23" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/workflows/ephys/Extensions/GetQuaternionTwist.cs
+++ b/workflows/ephys/Extensions/GetQuaternionTwist.cs
@@ -1,0 +1,41 @@
+using Bonsai;
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Numerics;
+
+[Combinator]
+[Description("Calculates the twist component around the specified axis for each quaternion in the sequence.")]
+[WorkflowElementCategory(ElementCategory.Transform)]
+public class GetQuaternionTwist
+{
+    public GetQuaternionTwist()
+    {
+        Direction = Vector3.UnitZ;
+    }
+
+    [TypeConverter(typeof(NumericRecordConverter))]
+    [Description("The direction vector around which to calculate the twist component.")]
+    public Vector3 Direction { get; set; }
+
+    static float Dot(Vector3 a, Vector3 b)
+    {
+        return a.X * b.X + a.Y * b.Y + a.Z * b.Z;
+    }
+
+    public IObservable<Quaternion> Process(IObservable<Quaternion> source)
+    {
+        // project rotation axis onto the direction axis
+        return source.Select(rotation =>
+        {
+            var direction = Direction;
+            var rotationAxis = new Vector3(rotation.X, rotation.Y, rotation.Z);
+            var projection = Dot(rotationAxis, direction) / Dot(direction, direction) * direction;
+            var twist = new Quaternion(projection, rotation.W);
+            twist = Quaternion.Normalize(twist);
+            return twist;
+        });
+    }
+}

--- a/workflows/ephys/Extensions/GetQuaternionTwist.cs
+++ b/workflows/ephys/Extensions/GetQuaternionTwist.cs
@@ -32,9 +32,15 @@ public class GetQuaternionTwist
         {
             var direction = Direction;
             var rotationAxis = new Vector3(rotation.X, rotation.Y, rotation.Z);
-            var projection = Dot(rotationAxis, direction) / Dot(direction, direction) * direction;
+            var dotProduct = Dot(rotationAxis, direction);
+            var projection = dotProduct / Dot(direction, direction) * direction;
             var twist = new Quaternion(projection, rotation.W);
             twist = Quaternion.Normalize(twist);
+            if (dotProduct < 0) // account for angle-axis flipping
+            {
+                twist = -twist;
+            }
+
             return twist;
         });
     }


### PR DESCRIPTION
We observed a singularity in quaternion angle decomposition upon reaching 90 degree pitch rotations which was causing excess tangling to accumulate in the commutator controller. This PR attempts to solve the issue by using [swing-twist decomposition](https://www.euclideanspace.com/maths/geometry/rotations/for/decomposition/) and ensuring quaternion scalar components are positive.