### PR TITLE
Remove singularity by changing rotation axis

### DIFF
--- a/workflows/ephys/Extensions/CommutatorController.bonsai
+++ b/workflows/ephys/Extensions/CommutatorController.bonsai
@@ -77,7 +77,7 @@
               <Combinator xsi:type="p1:GetQuaternionTwistAngle">
                 <p1:Direction>
                   <p1:X>0</p1:X>
-                  <p1:Y>0</p1:Y>
+                  <p1:Y>1</p1:Y>
                   <p1:Z>1</p1:Z>
                 </p1:Direction>
               </Combinator>


### PR DESCRIPTION
Following up on #526 we observed there was still a remaining singularity when rolling 90 degrees either left or right. Any yaw rotations past this 90 degree singular angle would not be compensated for by the opposite rotation when these are performed close to the singularity.

This was fixed by changing the rotation vector from (0, 0, 1) to (0, 1, 1). The new correction was validated in the field and it was found to stabilize tangling beyond the 8h mark.

It remains unclear in which way exactly this new vector eliminates the singularity. We suspect it is still there, just now moved to a new point which is less likely to be reached during natural movement.