### PR TITLE
Calibrate linear motor controller for straight wire without loops

### DIFF
--- a/workflows/social/Social-AEON2.bonsai
+++ b/workflows/social/Social-AEON2.bonsai
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WorkflowBuilder Version="2.8.1"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
@@ -918,16 +918,16 @@
                   <Expression xsi:type="IncludeWorkflow" Path="Extensions\TetherSlackController.bonsai">
                     <TrackingEvents>TrackingTop</TrackingEvents>
                     <ArenaCenter>
-                      <X>731</X>
+                      <X>700</X>
                       <Y>561</Y>
                     </ArenaCenter>
                     <ArenaRadiusPixels>510</ArenaRadiusPixels>
-                    <ArenaRadiusCentimeters>100</ArenaRadiusCentimeters>
+                    <ArenaRadiusCentimeters>90</ArenaRadiusCentimeters>
                     <TetherGuideAltitude>129.5</TetherGuideAltitude>
                     <TetherGuideHeight>17</TetherGuideHeight>
                     <TetherMaxSlackLength>58.523</TetherMaxSlackLength>
                     <LinearRailLength>56</LinearRailLength>
-                    <RadialDistanceOffset>0</RadialDistanceOffset>
+                    <RadialDistanceOffset>15</RadialDistanceOffset>
                     <LinearDriveSetPosition>LinearDriveSetPosition</LinearDriveSetPosition>
                   </Expression>
                   <Expression xsi:type="WorkflowOutput" />

--- a/workflows/social/Social-AEON2.bonsai
+++ b/workflows/social/Social-AEON2.bonsai
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <WorkflowBuilder Version="2.8.1"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
@@ -612,9 +612,9 @@
                         </Expression>
                         <Expression xsi:type="IncludeWorkflow" Path="Extensions\LinearDriveController.bonsai">
                           <LinearDrivePosition>LinearDrivePosition</LinearDrivePosition>
-                          <LimitContinuousCurrent>2500</LimitContinuousCurrent>
-                          <LimitPeakCurrent>2500</LimitPeakCurrent>
-                          <LimitSpeed>20000</LimitSpeed>
+                          <LimitContinuousCurrent>4500</LimitContinuousCurrent>
+                          <LimitPeakCurrent>5500</LimitPeakCurrent>
+                          <LimitSpeed>50000</LimitSpeed>
                           <LinearDriveSetPosition>LinearDriveSetPosition</LinearDriveSetPosition>
                           <PortName>COM12</PortName>
                           <LinearDriveEvents>LinearDriveEvents</LinearDriveEvents>


### PR DESCRIPTION
The linear motor controller parameters had to be updated following recent adjustments to the tether. Specifically, the extra loop and spring arrangement was removed and replaced with a straight wire.

The linear motor speed and current limits had to be increased to account for high-speed displacements past the arena centre, and the calibration of the arena centre itself also had to be adjusted for optimal operation.