### PR TITLE
Update bootstrapper and core packages to avoid blocking command-line scripts

### DIFF
--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -6,14 +6,14 @@
     <Package id="Aeon.Environment" version="0.1.0-build240102" />
     <Package id="Aeon.Foraging" version="0.1.0-build231202" />
     <Package id="AsyncIO" version="0.1.69" />
-    <Package id="Bonsai" version="2.8.1" />
+    <Package id="Bonsai" version="2.8.3" />
     <Package id="Bonsai.Audio" version="2.8.0" />
-    <Package id="Bonsai.Core" version="2.8.1" />
-    <Package id="Bonsai.Design" version="2.8.0" />
+    <Package id="Bonsai.Core" version="2.8.2" />
+    <Package id="Bonsai.Design" version="2.8.1" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
     <Package id="Bonsai.Dsp" version="2.8.0" />
     <Package id="Bonsai.Dsp.Design" version="2.8.0" />
-    <Package id="Bonsai.Editor" version="2.8.0" />
+    <Package id="Bonsai.Editor" version="2.8.2" />
     <Package id="Bonsai.Harp" version="3.5.2" />
     <Package id="Bonsai.Harp.Design" version="3.5.0" />
     <Package id="Bonsai.Numerics" version="0.9.0" />
@@ -116,14 +116,14 @@
     <AssemblyLocation assemblyName="AsyncIO" processorArchitecture="MSIL" location="Packages\AsyncIO.0.1.69\lib\net40\AsyncIO.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="X86" location="Packages\Bonsai.Pylon.0.3.0\build\net462\bin\x86\Basler.Pylon.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="Amd64" location="Packages\Bonsai.Pylon.0.3.0\build\net462\bin\x64\Basler.Pylon.dll" />
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.1\lib\net48\Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.3\lib\net48\Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Audio" processorArchitecture="MSIL" location="Packages\Bonsai.Audio.2.8.0\lib\net462\Bonsai.Audio.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.1\lib\net462\Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.2\lib\net462\Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.1\lib\net462\Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.Design.Visualizers.2.8.0\lib\net462\Bonsai.Design.Visualizers.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.2.8.0\lib\net462\Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.Design.2.8.0\lib\net462\Bonsai.Dsp.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.0\lib\net472\Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.2\lib\net472\Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.Harp" processorArchitecture="MSIL" location="Packages\Bonsai.Harp.3.5.2\lib\net462\Bonsai.Harp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Harp.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Harp.Design.3.5.0\lib\net462\Bonsai.Harp.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages\Bonsai.Numerics.0.9.0\lib\net462\Bonsai.Numerics.dll" />


### PR DESCRIPTION
The current bootstrapper version used for experiments was suffering from https://github.com/bonsai-rx/bonsai/issues/1740 which has been resolved in the latest release.