### PR TITLE
Add watchdog monitor for auto-restarting ephys workflows

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2023-2024, University College London
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -7,14 +7,14 @@
     <Package id="Aeon.Foraging" version="0.1.0-build231202" />
     <Package id="Aeon.LinearDrive" version="0.1.0-preview230921" />
     <Package id="AsyncIO" version="0.1.69" />
-    <Package id="Bonsai" version="2.8.1" />
+    <Package id="Bonsai" version="2.8.3" />
     <Package id="Bonsai.Audio" version="2.8.0" />
-    <Package id="Bonsai.Core" version="2.8.1" />
-    <Package id="Bonsai.Design" version="2.8.0" />
+    <Package id="Bonsai.Core" version="2.8.2" />
+    <Package id="Bonsai.Design" version="2.8.1" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
     <Package id="Bonsai.Dsp" version="2.8.0" />
     <Package id="Bonsai.Dsp.Design" version="2.8.0" />
-    <Package id="Bonsai.Editor" version="2.8.0" />
+    <Package id="Bonsai.Editor" version="2.8.2" />
     <Package id="Bonsai.Harp" version="3.5.2" />
     <Package id="Bonsai.Harp.Design" version="3.5.0" />
     <Package id="Bonsai.Numerics" version="0.9.0" />
@@ -119,14 +119,14 @@
     <AssemblyLocation assemblyName="AsyncIO" processorArchitecture="MSIL" location="Packages\AsyncIO.0.1.69\lib\net40\AsyncIO.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="X86" location="Packages\Bonsai.Pylon.0.3.0\build\net462\bin\x86\Basler.Pylon.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="Amd64" location="Packages\Bonsai.Pylon.0.3.0\build\net462\bin\x64\Basler.Pylon.dll" />
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.1\lib\net48\Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.3\lib\net48\Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Audio" processorArchitecture="MSIL" location="Packages\Bonsai.Audio.2.8.0\lib\net462\Bonsai.Audio.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.1\lib\net462\Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.2\lib\net462\Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.1\lib\net462\Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.Design.Visualizers.2.8.0\lib\net462\Bonsai.Design.Visualizers.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.2.8.0\lib\net462\Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.Design.2.8.0\lib\net462\Bonsai.Dsp.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.0\lib\net472\Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.2\lib\net472\Bonsai.Editor.dll" />
     <AssemblyLocation assemblyName="Bonsai.Harp" processorArchitecture="MSIL" location="Packages\Bonsai.Harp.3.5.2\lib\net462\Bonsai.Harp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Harp.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Harp.Design.3.5.0\lib\net462\Bonsai.Harp.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages\Bonsai.Numerics.0.9.0\lib\net462\Bonsai.Numerics.dll" />

--- a/workflows/ephys/Ephys-AEONX1.bonsai
+++ b/workflows/ephys/Ephys-AEONX1.bonsai
@@ -577,6 +577,7 @@
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\Alerts.bonsai" />
       <Expression xsi:type="IncludeWorkflow" Path="Extensions\Logging.bonsai" />
+      <Expression xsi:type="IncludeWorkflow" Path="Extensions\StreamMonitor.bonsai" />
       <Expression xsi:type="SubscribeSubject">
         <Name>NeuropixelsV2BetaProbeA</Name>
       </Expression>
@@ -591,7 +592,7 @@
       </Expression>
     </Nodes>
     <Edges>
-      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/workflows/ephys/Ephys-AEONX1.bonsai.layout
+++ b/workflows/ephys/Ephys-AEONX1.bonsai.layout
@@ -416,7 +416,7 @@
             <TimeSeriesVisualizer>
               <Capacity>640</Capacity>
               <Min>0</Min>
-              <Max>1200000</Max>
+              <Max>400000</Max>
               <AutoScale>true</AutoScale>
             </TimeSeriesVisualizer>
           </VisualizerSettings>
@@ -426,8 +426,8 @@
           <VisualizerSettings>
             <TimeSeriesVisualizer>
               <Capacity>640</Capacity>
-              <Min>3796625350</Min>
-              <Max>3796625420</Max>
+              <Min>3800013408</Min>
+              <Max>3800013416</Max>
               <AutoScale>true</AutoScale>
             </TimeSeriesVisualizer>
           </VisualizerSettings>
@@ -437,8 +437,8 @@
           <VisualizerSettings>
             <TimeSeriesVisualizer>
               <Capacity>640</Capacity>
-              <Min>-0.2</Min>
-              <Max>0.7</Max>
+              <Min>-0</Min>
+              <Max>0.004</Max>
               <AutoScale>true</AutoScale>
             </TimeSeriesVisualizer>
           </VisualizerSettings>
@@ -507,6 +507,18 @@
     <WindowState>Normal</WindowState>
   </DialogSettings>
   <DialogSettings>
+    <Visible>false</Visible>
+    <Location>
+      <X>0</X>
+      <Y>0</Y>
+    </Location>
+    <Size>
+      <Width>0</Width>
+      <Height>0</Height>
+    </Size>
+    <WindowState>Normal</WindowState>
+  </DialogSettings>
+  <DialogSettings>
     <Visible>true</Visible>
     <Location>
       <X>210</X>
@@ -522,11 +534,11 @@
       <MatVisualizer>
         <XMin>0</XMin>
         <XMax>30000</XMax>
-        <YMin>-500000</YMin>
+        <YMin>-499999.99999999994</YMin>
         <YMax>3500000</YMax>
         <AutoScaleX>true</AutoScaleX>
         <AutoScaleY>true</AutoScaleY>
-        <SelectedPage>2</SelectedPage>
+        <SelectedPage>0</SelectedPage>
         <ChannelsPerPage>32</ChannelsPerPage>
         <OverlayChannels>true</OverlayChannels>
         <ChannelOffset>100000</ChannelOffset>
@@ -551,11 +563,11 @@
       <SpikeWaveformCollectionVisualizer>
         <XMin>0</XMin>
         <XMax>60</XMax>
-        <YMin>-400000</YMin>
-        <YMax>399999.99999999994</YMax>
+        <YMin>-200000</YMin>
+        <YMax>200000</YMax>
         <AutoScaleX>true</AutoScaleX>
         <AutoScaleY>true</AutoScaleY>
-        <SelectedPage>2</SelectedPage>
+        <SelectedPage>0</SelectedPage>
         <ChannelsPerPage>32</ChannelsPerPage>
         <OverlayChannels>false</OverlayChannels>
         <ChannelOffset>0</ChannelOffset>

--- a/workflows/ephys/Ephys-AEONX1.cmd
+++ b/workflows/ephys/Ephys-AEONX1.cmd
@@ -1,1 +1,4 @@
+:loop
 powershell -ep Bypass -c "& ..\..\bonsai\Bonsai.exe --lib $(Resolve-Path ..\onix-refactor\OpenEphys.Onix\OpenEphys.Onix\bin\x64\Release\net472\) Ephys-AEONX1.bonsai %* *>&1 | tee -a Ephys-AEONX1.log"
+timeout /t 5
+goto :loop

--- a/workflows/ephys/Extensions/Alerts.bonsai
+++ b/workflows/ephys/Extensions/Alerts.bonsai
@@ -238,6 +238,9 @@ Item2.Seconds as Timestamp)</scr:Expression>
                 </Edges>
               </Workflow>
             </Expression>
+            <Expression xsi:type="rx:PublishSubject">
+              <Name>TimeoutAlerts</Name>
+            </Expression>
             <Expression xsi:type="Format">
               <Format>## **Stream Timeout**
 **Stream**: {0}
@@ -274,9 +277,10 @@ Item2.Seconds as Timestamp)</scr:Expression>
             <Edge From="13" To="14" Label="Source1" />
             <Edge From="15" To="16" Label="Source1" />
             <Edge From="17" To="18" Label="Source1" />
-            <Edge From="17" To="20" Label="Source1" />
             <Edge From="18" To="19" Label="Source1" />
-            <Edge From="20" To="21" Label="Source1" />
+            <Edge From="18" To="21" Label="Source1" />
+            <Edge From="19" To="20" Label="Source1" />
+            <Edge From="21" To="22" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/workflows/ephys/Extensions/Alerts.bonsai
+++ b/workflows/ephys/Extensions/Alerts.bonsai
@@ -198,7 +198,7 @@ Item2.Seconds as Timestamp)</scr:Expression>
               <Name>StreamTimeoutMonitor</Name>
               <Workflow>
                 <Nodes>
-                  <Expression xsi:type="IncludeWorkflow" Path="Extensions\StreamTimeout.bonsai">
+                  <Expression xsi:type="IncludeWorkflow" Path="Extensions\HarpSyncTimeout.bonsai">
                     <StreamEvents>OnixHarpSync</StreamEvents>
                     <DueTime>PT2S</DueTime>
                   </Expression>

--- a/workflows/ephys/Extensions/HarpSyncTimeout.bonsai
+++ b/workflows/ephys/Extensions/HarpSyncTimeout.bonsai
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.1"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
+                 xmlns:spk="clr-namespace:Bonsai.Spinnaker;assembly=Bonsai.Spinnaker"
+                 xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Description>Detects that the specified stream stopped producing values.</Description>
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="StreamEvents" />
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>OnixHarpSync</Name>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="DueTime" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:TimeoutNotification.bonsai">
+        <DueTime>PT2S</DueTime>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Value" DisplayName="Name" />
+            </Expression>
+            <Expression xsi:type="PropertySource" TypeArguments="SubscribeSubject(harp:Timestamped(spk:SpinnakerDataFrame)),sys:String">
+              <MemberName>Name</MemberName>
+              <Value>OnixHarpSync</Value>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Take">
+                <rx:Count>1</rx:Count>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:CombineLatest" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Item2</Selector>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Timestamp" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="harp:CreateTimestamped" />
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="0" To="4" Label="Source1" />
+      <Edge From="1" To="3" Label="Source1" />
+      <Edge From="2" To="3" Label="Source2" />
+      <Edge From="3" To="5" Label="Source1" />
+      <Edge From="4" To="5" Label="Source2" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/workflows/ephys/Extensions/StreamMonitor.bonsai
+++ b/workflows/ephys/Extensions/StreamMonitor.bonsai
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.1"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>TimeoutAlerts</Name>
+      </Expression>
+      <Expression xsi:type="scr:ExpressionCondition">
+        <scr:Expression>Value.Contains("NeuropixelsV2BetaProbe")</scr:Expression>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Skip">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Value</Selector>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="aeon:GetDateTime" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Zip" />
+      </Expression>
+      <Expression xsi:type="Format">
+        <Format>{0} stopped streaming@{1}.</Format>
+        <Selector>Item1,Item2</Selector>
+      </Expression>
+      <Expression xsi:type="InputMapping">
+        <PropertyMappings>
+          <Property Name="Message" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="aeon:ThrowException">
+          <aeon:Message />
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="3" To="5" Label="Source1" />
+      <Edge From="4" To="6" Label="Source1" />
+      <Edge From="5" To="6" Label="Source2" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>


### PR DESCRIPTION
- [Ensure harp sync timeout notification is sent](https://github.com/SainsburyWellcomeCentre/aeon_experiments/commit/bc197417383daeb356e13c0eee2b51db417a2a04)

The ONIX harp sync timeout notification depended on its own stream for the timestamp and therefore was never sent out. We decided to use a system timestamp instead so at least some notification is sent.

- [Add auto-restart loop to ephys launch script](https://github.com/SainsburyWellcomeCentre/aeon_experiments/commit/d575d8912907750edc3549c53eb52435c860e226)

We have observed sporadic crashes due to tether and other physical hardware issues. Due to the critical nature of the rotary commutator to ensure stability of experiments, we decided to have an auto-restart loop with a short timer on the launch script which will attempt to restart the workflow automatically.

- [Throw exception if probe stops streaming](https://github.com/SainsburyWellcomeCentre/aeon_experiments/commit/cb0c662e9eefef126afe448d4635cbbd3e1eaca6)

Another issue we have encountered related to tether and connection problems is on occasion the probe ephys stream might simply stop. We now report this as an error and crash the workflow so the auto-restart loop can act through a single pathway.

Fixes #541 