### PR TITLE
Add dummy patches and extra RFID readers

### DIFF
--- a/workflows/social/Extensions/ControlPanel.bonsai
+++ b/workflows/social/Extensions/ControlPanel.bonsai
@@ -766,6 +766,32 @@ P3 (rate: {8}, d0: {7}, thr: {6:0.##})</Format>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />
             <Expression xsi:type="SubscribeSubject">
+              <Name>PatchDummy1PelletDelivered</Name>
+            </Expression>
+            <Expression xsi:type="rx:Condition">
+              <Name>RisingEdge</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="WorkflowInput">
+                    <Name>Source1</Name>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>Value</Selector>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="1" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:PatchDispenser.bonsai">
+              <ControllerEvents>PatchDummy1Controller</ControllerEvents>
+              <DispenserState>PatchDummy1Dispenser</DispenserState>
+              <Name>PatchDummy1</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
               <Name>Patch1Controller</Name>
             </Expression>
             <Expression xsi:type="Combinator">
@@ -1009,22 +1035,24 @@ P3 (rate: {8}, d0: {7}, thr: {6:0.##})</Format>
             <Edge From="41" To="42" Label="Source1" />
             <Edge From="43" To="44" Label="Source1" />
             <Edge From="44" To="45" Label="Source1" />
-            <Edge From="44" To="47" Label="Source1" />
-            <Edge From="45" To="46" Label="Source1" />
+            <Edge From="46" To="47" Label="Source1" />
             <Edge From="47" To="48" Label="Source1" />
+            <Edge From="47" To="50" Label="Source1" />
             <Edge From="48" To="49" Label="Source1" />
             <Edge From="50" To="51" Label="Source1" />
             <Edge From="51" To="52" Label="Source1" />
-            <Edge From="51" To="54" Label="Source1" />
-            <Edge From="52" To="53" Label="Source1" />
+            <Edge From="53" To="54" Label="Source1" />
             <Edge From="54" To="55" Label="Source1" />
+            <Edge From="54" To="57" Label="Source1" />
             <Edge From="55" To="56" Label="Source1" />
             <Edge From="57" To="58" Label="Source1" />
             <Edge From="58" To="59" Label="Source1" />
-            <Edge From="58" To="61" Label="Source1" />
-            <Edge From="59" To="60" Label="Source1" />
+            <Edge From="60" To="61" Label="Source1" />
             <Edge From="61" To="62" Label="Source1" />
+            <Edge From="61" To="64" Label="Source1" />
             <Edge From="62" To="63" Label="Source1" />
+            <Edge From="64" To="65" Label="Source1" />
+            <Edge From="65" To="66" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/workflows/social/Extensions/Declarations.bonsai
+++ b/workflows/social/Extensions/Declarations.bonsai
@@ -34,6 +34,9 @@
       <Expression xsi:type="aeon:StateRecoverySubject" TypeArguments="sys:ValueTuple(sys:Double,sys:Double,sys:Double)">
         <aeon:Name>Patch3State</aeon:Name>
       </Expression>
+      <Expression xsi:type="aeon:StateRecoverySubject" TypeArguments="sys:ValueTuple(sys:Double,sys:Double,sys:Double)">
+        <aeon:Name>PatchDummy1State</aeon:Name>
+      </Expression>
       <Expression xsi:type="aeon:StateRecoverySubject" TypeArguments="p1:BlockState">
         <aeon:Name>BlockState</aeon:Name>
       </Expression>
@@ -63,6 +66,9 @@
       </Expression>
       <Expression xsi:type="aeon:StateRecoverySubject" TypeArguments="aeon-frg:DispenserState">
         <aeon:Name>Patch3Dispenser</aeon:Name>
+      </Expression>
+      <Expression xsi:type="aeon:StateRecoverySubject" TypeArguments="aeon-frg:DispenserState">
+        <aeon:Name>PatchDummy1Dispenser</aeon:Name>
       </Expression>
       <Expression xsi:type="rx:BehaviorSubject" TypeArguments="harp:Timestamped(aeon-env:EnvironmentSubjectStateMetadata)">
         <rx:Name>SubjectState</rx:Name>

--- a/workflows/social/Extensions/Logging.bonsai
+++ b/workflows/social/Extensions/Logging.bonsai
@@ -467,6 +467,55 @@ Item3 as Delta)</scr:Expression>
         <Selector xsi:nil="true" />
       </Expression>
       <Expression xsi:type="SubscribeSubject">
+        <Name>PatchDummy1Events</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>PatchDummy1Dispenser</Name>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Bonsai.Harp:WithLatestTimestamp.bonsai">
+        <Name>Patch3Events</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="aeon-frg:FormatDispenserState">
+          <aeon-frg:Address>200</aeon-frg:Address>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Merge" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogHarpState.bonsai">
+        <LogName>PatchDummy1</LogName>
+        <Heartbeats>Heartbeats</Heartbeats>
+        <ClosingDuration>PT2S</ClosingDuration>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>PatchDummy1State</Name>
+      </Expression>
+      <Expression xsi:type="scr:ExpressionTransform">
+        <scr:Expression>new(
+Item1 as Threshold,
+Item2 as D1,
+Item3 as Delta)</scr:Expression>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>PatchDummy1Events</Name>
+      </Expression>
+      <Expression xsi:type="harp:Parse">
+        <harp:Register xsi:type="harp:ParseMessagePayload">
+          <harp:PayloadType>Timestamp</harp:PayloadType>
+          <harp:IsArray>false</harp:IsArray>
+        </harp:Register>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:WithLatestFrom" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogData.bonsai">
+        <Heartbeats>Heartbeats</Heartbeats>
+        <ClosingDuration>PT2S</ClosingDuration>
+        <LogName>PatchDummy1_State</LogName>
+        <Selector xsi:nil="true" />
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
         <Name>BlockState</Name>
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Bonsai.Harp:WithLatestTimestamp.bonsai">
@@ -635,6 +684,14 @@ new(Value.Id as Id,
         <Heartbeats>Heartbeats</Heartbeats>
         <ClosingDuration>PT2S</ClosingDuration>
       </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>PatchDummy1RfidEvents</Name>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogHarpState.bonsai">
+        <LogName>PatchDummy1Rfid</LogName>
+        <Heartbeats>Heartbeats</Heartbeats>
+        <ClosingDuration>PT2S</ClosingDuration>
+      </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:Timer">
           <rx:DueTime>PT0S</rx:DueTime>
@@ -783,55 +840,66 @@ new(Value.Id as Id,
       <Edge From="77" To="78" Label="Source1" />
       <Edge From="78" To="79" Label="Source2" />
       <Edge From="79" To="80" Label="Source1" />
-      <Edge From="81" To="82" Label="Source1" />
+      <Edge From="81" To="85" Label="Source1" />
       <Edge From="82" To="83" Label="Source1" />
-      <Edge From="84" To="85" Label="Source1" />
-      <Edge From="86" To="87" Label="Source1" />
-      <Edge From="88" To="90" Label="Source1" />
-      <Edge From="89" To="90" Label="Source2" />
-      <Edge From="90" To="91" Label="Source1" />
-      <Edge From="92" To="93" Label="Source1" />
+      <Edge From="83" To="84" Label="Source1" />
+      <Edge From="84" To="85" Label="Source2" />
+      <Edge From="85" To="86" Label="Source1" />
+      <Edge From="87" To="88" Label="Source1" />
+      <Edge From="88" To="91" Label="Source1" />
+      <Edge From="89" To="90" Label="Source1" />
+      <Edge From="90" To="91" Label="Source2" />
+      <Edge From="91" To="92" Label="Source1" />
+      <Edge From="93" To="94" Label="Source1" />
       <Edge From="94" To="95" Label="Source1" />
       <Edge From="96" To="97" Label="Source1" />
-      <Edge From="97" To="110" Label="Source1" />
       <Edge From="98" To="99" Label="Source1" />
-      <Edge From="99" To="110" Label="Source2" />
-      <Edge From="100" To="101" Label="Source1" />
-      <Edge From="101" To="110" Label="Source3" />
+      <Edge From="100" To="102" Label="Source1" />
+      <Edge From="101" To="102" Label="Source2" />
       <Edge From="102" To="103" Label="Source1" />
-      <Edge From="103" To="110" Label="Source4" />
       <Edge From="104" To="105" Label="Source1" />
-      <Edge From="105" To="110" Label="Source5" />
       <Edge From="106" To="107" Label="Source1" />
-      <Edge From="107" To="110" Label="Source6" />
       <Edge From="108" To="109" Label="Source1" />
-      <Edge From="109" To="110" Label="Source7" />
+      <Edge From="109" To="122" Label="Source1" />
       <Edge From="110" To="111" Label="Source1" />
-      <Edge From="111" To="112" Label="Source1" />
-      <Edge From="113" To="114" Label="Source1" />
-      <Edge From="115" To="116" Label="Source1" />
-      <Edge From="117" To="118" Label="Source1" />
-      <Edge From="119" To="120" Label="Source1" />
-      <Edge From="121" To="122" Label="Source1" />
+      <Edge From="111" To="122" Label="Source2" />
+      <Edge From="112" To="113" Label="Source1" />
+      <Edge From="113" To="122" Label="Source3" />
+      <Edge From="114" To="115" Label="Source1" />
+      <Edge From="115" To="122" Label="Source4" />
+      <Edge From="116" To="117" Label="Source1" />
+      <Edge From="117" To="122" Label="Source5" />
+      <Edge From="118" To="119" Label="Source1" />
+      <Edge From="119" To="122" Label="Source6" />
+      <Edge From="120" To="121" Label="Source1" />
+      <Edge From="121" To="122" Label="Source7" />
+      <Edge From="122" To="123" Label="Source1" />
       <Edge From="123" To="124" Label="Source1" />
       <Edge From="125" To="126" Label="Source1" />
-      <Edge From="126" To="129" Label="Source1" />
       <Edge From="127" To="128" Label="Source1" />
-      <Edge From="128" To="129" Label="Source2" />
       <Edge From="129" To="130" Label="Source1" />
-      <Edge From="130" To="131" Label="Source1" />
-      <Edge From="132" To="133" Label="Source1" />
+      <Edge From="131" To="132" Label="Source1" />
       <Edge From="133" To="134" Label="Source1" />
-      <Edge From="134" To="142" Label="Source1" />
       <Edge From="135" To="136" Label="Source1" />
-      <Edge From="136" To="142" Label="Source2" />
       <Edge From="137" To="138" Label="Source1" />
-      <Edge From="138" To="139" Label="Source1" />
-      <Edge From="139" To="142" Label="Source3" />
-      <Edge From="140" To="141" Label="Source1" />
-      <Edge From="141" To="142" Label="Source4" />
-      <Edge From="142" To="143" Label="Source1" />
+      <Edge From="139" To="140" Label="Source1" />
+      <Edge From="140" To="143" Label="Source1" />
+      <Edge From="141" To="142" Label="Source1" />
+      <Edge From="142" To="143" Label="Source2" />
+      <Edge From="143" To="144" Label="Source1" />
       <Edge From="144" To="145" Label="Source1" />
+      <Edge From="146" To="147" Label="Source1" />
+      <Edge From="147" To="148" Label="Source1" />
+      <Edge From="148" To="156" Label="Source1" />
+      <Edge From="149" To="150" Label="Source1" />
+      <Edge From="150" To="156" Label="Source2" />
+      <Edge From="151" To="152" Label="Source1" />
+      <Edge From="152" To="153" Label="Source1" />
+      <Edge From="153" To="156" Label="Source3" />
+      <Edge From="154" To="155" Label="Source1" />
+      <Edge From="155" To="156" Label="Source4" />
+      <Edge From="156" To="157" Label="Source1" />
+      <Edge From="158" To="159" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/workflows/social/Extensions/Logging.bonsai
+++ b/workflows/social/Extensions/Logging.bonsai
@@ -661,6 +661,22 @@ new(Value.Id as Id,
         <ClosingDuration>PT2S</ClosingDuration>
       </Expression>
       <Expression xsi:type="SubscribeSubject">
+        <Name>GateEastRfidEvents</Name>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogHarpState.bonsai">
+        <LogName>GateEastRfid</LogName>
+        <Heartbeats>Heartbeats</Heartbeats>
+        <ClosingDuration>PT2S</ClosingDuration>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>GateWestRfidEvents</Name>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogHarpState.bonsai">
+        <LogName>GateWestRfid</LogName>
+        <Heartbeats>Heartbeats</Heartbeats>
+        <ClosingDuration>PT2S</ClosingDuration>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
         <Name>Patch1RfidEvents</Name>
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogHarpState.bonsai">
@@ -883,23 +899,25 @@ new(Value.Id as Id,
       <Edge From="135" To="136" Label="Source1" />
       <Edge From="137" To="138" Label="Source1" />
       <Edge From="139" To="140" Label="Source1" />
-      <Edge From="140" To="143" Label="Source1" />
       <Edge From="141" To="142" Label="Source1" />
-      <Edge From="142" To="143" Label="Source2" />
       <Edge From="143" To="144" Label="Source1" />
-      <Edge From="144" To="145" Label="Source1" />
-      <Edge From="146" To="147" Label="Source1" />
+      <Edge From="144" To="147" Label="Source1" />
+      <Edge From="145" To="146" Label="Source1" />
+      <Edge From="146" To="147" Label="Source2" />
       <Edge From="147" To="148" Label="Source1" />
-      <Edge From="148" To="156" Label="Source1" />
-      <Edge From="149" To="150" Label="Source1" />
-      <Edge From="150" To="156" Label="Source2" />
+      <Edge From="148" To="149" Label="Source1" />
+      <Edge From="150" To="151" Label="Source1" />
       <Edge From="151" To="152" Label="Source1" />
-      <Edge From="152" To="153" Label="Source1" />
-      <Edge From="153" To="156" Label="Source3" />
-      <Edge From="154" To="155" Label="Source1" />
-      <Edge From="155" To="156" Label="Source4" />
+      <Edge From="152" To="160" Label="Source1" />
+      <Edge From="153" To="154" Label="Source1" />
+      <Edge From="154" To="160" Label="Source2" />
+      <Edge From="155" To="156" Label="Source1" />
       <Edge From="156" To="157" Label="Source1" />
+      <Edge From="157" To="160" Label="Source3" />
       <Edge From="158" To="159" Label="Source1" />
+      <Edge From="159" To="160" Label="Source4" />
+      <Edge From="160" To="161" Label="Source1" />
+      <Edge From="162" To="163" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/workflows/social/Social-AEON3.bonsai
+++ b/workflows/social/Social-AEON3.bonsai
@@ -454,6 +454,42 @@
                     </Workflow>
                   </Expression>
                   <Expression xsi:type="GroupWorkflow">
+                    <Name>PatchDummy1</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="PortName" />
+                          <Property Name="WheelDisplacement" />
+                          <Property Name="PelletDelivered" />
+                          <Property Name="DeliverPellet" />
+                          <Property Name="PatchEvents" />
+                          <Property Name="Radius" />
+                          <Property Name="SampleRate" />
+                          <Property Name="ResetFeeder" />
+                          <Property Name="DueTime" />
+                          <Property Name="Count" />
+                        </Expression>
+                        <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:UndergroundFeeder.bonsai">
+                          <PatchEvents>PatchDummy1Events</PatchEvents>
+                          <SampleRate>SampleRate500Hz</SampleRate>
+                          <DeliverPellet>PatchDummy1DeliverPellet</DeliverPellet>
+                          <PelletDelivered>PatchDummy1PelletDelivered</PelletDelivered>
+                          <DueTime>PT1S</DueTime>
+                          <Count>2</Count>
+                          <ResetFeeder>PatchDummy1ResetFeeder</ResetFeeder>
+                          <PortName>COM20</PortName>
+                          <Radius>-4</Radius>
+                          <WheelDisplacement>PatchDummy1WheelDisplacement</WheelDisplacement>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
                     <Name>Nest</Name>
                     <Workflow>
                       <Nodes>
@@ -646,6 +682,35 @@
                             <Y>348</Y>
                           </Location>
                           <InboundRfidDetected>Patch3RfidInboundDetected</InboundRfidDetected>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
+                    <Name>PatchDummy1Rfid</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="HardwareNotificationsState" />
+                          <Property Name="PortName" />
+                          <Property Name="RfidEvents" />
+                          <Property Name="Location" />
+                          <Property Name="InboundRfidDetected" />
+                        </Expression>
+                        <Expression xsi:type="IncludeWorkflow" Path="Aeon.Environment:RfidReader.bonsai">
+                          <HardwareNotificationsState>None</HardwareNotificationsState>
+                          <PortName>COM21</PortName>
+                          <RfidEvents>PatchDummy1RfidEvents</RfidEvents>
+                          <Location>
+                            <X>565</X>
+                            <Y>372</Y>
+                          </Location>
+                          <InboundRfidDetected>PatchDummy1RfidInboundDetected</InboundRfidDetected>
                         </Expression>
                         <Expression xsi:type="WorkflowOutput" />
                       </Nodes>

--- a/workflows/social/Social-AEON3.bonsai
+++ b/workflows/social/Social-AEON3.bonsai
@@ -605,6 +605,64 @@
                     </Workflow>
                   </Expression>
                   <Expression xsi:type="GroupWorkflow">
+                    <Name>GateEastRfid</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="HardwareNotificationsState" />
+                          <Property Name="PortName" />
+                          <Property Name="RfidEvents" />
+                          <Property Name="Location" />
+                          <Property Name="InboundRfidDetected" />
+                        </Expression>
+                        <Expression xsi:type="IncludeWorkflow" Path="Aeon.Environment:RfidReader.bonsai">
+                          <HardwareNotificationsState>None</HardwareNotificationsState>
+                          <PortName>COM22</PortName>
+                          <RfidEvents>GateEastRfidEvents</RfidEvents>
+                          <Location>
+                            <X>182</X>
+                            <Y>568</Y>
+                          </Location>
+                          <InboundRfidDetected>GateEastRfidInboundDetected</InboundRfidDetected>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
+                    <Name>GateWestRfid</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="HardwareNotificationsState" />
+                          <Property Name="PortName" />
+                          <Property Name="RfidEvents" />
+                          <Property Name="Location" />
+                          <Property Name="InboundRfidDetected" />
+                        </Expression>
+                        <Expression xsi:type="IncludeWorkflow" Path="Aeon.Environment:RfidReader.bonsai">
+                          <HardwareNotificationsState>None</HardwareNotificationsState>
+                          <PortName>COM23</PortName>
+                          <RfidEvents>GateWestRfidEvents</RfidEvents>
+                          <Location>
+                            <X>182</X>
+                            <Y>568</Y>
+                          </Location>
+                          <InboundRfidDetected>GateWestRfidInboundDetected</InboundRfidDetected>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
                     <Name>Patch1Rfid</Name>
                     <Workflow>
                       <Nodes>

--- a/workflows/social/Social-AEON4.bonsai
+++ b/workflows/social/Social-AEON4.bonsai
@@ -657,6 +657,64 @@
                     </Workflow>
                   </Expression>
                   <Expression xsi:type="GroupWorkflow">
+                    <Name>GateEastRfid</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="HardwareNotificationsState" />
+                          <Property Name="PortName" />
+                          <Property Name="RfidEvents" />
+                          <Property Name="Location" />
+                          <Property Name="InboundRfidDetected" />
+                        </Expression>
+                        <Expression xsi:type="IncludeWorkflow" Path="Aeon.Environment:RfidReader.bonsai">
+                          <HardwareNotificationsState>None</HardwareNotificationsState>
+                          <PortName>COM22</PortName>
+                          <RfidEvents>GateEastRfidEvents</RfidEvents>
+                          <Location>
+                            <X>182</X>
+                            <Y>568</Y>
+                          </Location>
+                          <InboundRfidDetected>GateEastRfidInboundDetected</InboundRfidDetected>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
+                    <Name>GateWestRfid</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="HardwareNotificationsState" />
+                          <Property Name="PortName" />
+                          <Property Name="RfidEvents" />
+                          <Property Name="Location" />
+                          <Property Name="InboundRfidDetected" />
+                        </Expression>
+                        <Expression xsi:type="IncludeWorkflow" Path="Aeon.Environment:RfidReader.bonsai">
+                          <HardwareNotificationsState>None</HardwareNotificationsState>
+                          <PortName>COM23</PortName>
+                          <RfidEvents>GateWestRfidEvents</RfidEvents>
+                          <Location>
+                            <X>182</X>
+                            <Y>568</Y>
+                          </Location>
+                          <InboundRfidDetected>GateWestRfidInboundDetected</InboundRfidDetected>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
                     <Name>Patch1Rfid</Name>
                     <Workflow>
                       <Nodes>

--- a/workflows/social/Social-AEON4.bonsai
+++ b/workflows/social/Social-AEON4.bonsai
@@ -506,6 +506,42 @@
                     </Workflow>
                   </Expression>
                   <Expression xsi:type="GroupWorkflow">
+                    <Name>PatchDummy1</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="PortName" />
+                          <Property Name="WheelDisplacement" />
+                          <Property Name="PelletDelivered" />
+                          <Property Name="DeliverPellet" />
+                          <Property Name="PatchEvents" />
+                          <Property Name="Radius" />
+                          <Property Name="SampleRate" />
+                          <Property Name="ResetFeeder" />
+                          <Property Name="DueTime" />
+                          <Property Name="Count" />
+                        </Expression>
+                        <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:UndergroundFeeder.bonsai">
+                          <PatchEvents>PatchDummy1Events</PatchEvents>
+                          <SampleRate>SampleRate500Hz</SampleRate>
+                          <DeliverPellet>PatchDummy1DeliverPellet</DeliverPellet>
+                          <PelletDelivered>PatchDummy1PelletDelivered</PelletDelivered>
+                          <DueTime>PT1S</DueTime>
+                          <Count>2</Count>
+                          <ResetFeeder>PatchDummy1ResetFeeder</ResetFeeder>
+                          <PortName>COM20</PortName>
+                          <Radius>-4</Radius>
+                          <WheelDisplacement>PatchDummy1WheelDisplacement</WheelDisplacement>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
                     <Name>Nest</Name>
                     <Workflow>
                       <Nodes>
@@ -698,6 +734,35 @@
                             <Y>372</Y>
                           </Location>
                           <InboundRfidDetected>Patch3RfidInboundDetected</InboundRfidDetected>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                        <Edge From="1" To="2" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
+                    <Name>PatchDummy1Rfid</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="ExternalizedMapping">
+                          <Property Name="HardwareNotificationsState" />
+                          <Property Name="PortName" />
+                          <Property Name="RfidEvents" />
+                          <Property Name="Location" />
+                          <Property Name="InboundRfidDetected" />
+                        </Expression>
+                        <Expression xsi:type="IncludeWorkflow" Path="Aeon.Environment:RfidReader.bonsai">
+                          <HardwareNotificationsState>None</HardwareNotificationsState>
+                          <PortName>COM21</PortName>
+                          <RfidEvents>PatchDummy1RfidEvents</RfidEvents>
+                          <Location>
+                            <X>565</X>
+                            <Y>372</Y>
+                          </Location>
+                          <InboundRfidDetected>PatchDummy1RfidInboundDetected</InboundRfidDetected>
                         </Expression>
                         <Expression xsi:type="WorkflowOutput" />
                       </Nodes>


### PR DESCRIPTION
This PR adds a new dummy and two new gate rfid's to the workflow of AEON4 and AEON3
- New dummy patch added to COM20
- New patch rfid added to COM21
- New gate east rfid added to COM22
- New gate west rfid added to COM23
- Change Logger to log all events from the new rfid's  
- Change ControlPanel to add a new patch controller for the dummy patch 
- Change Declarations to instantiate the subjects used by the logger and control panel 

Related to #531 and #530