### PR TITLE
Rearrange control panel layout to include dummy patch activity

### DIFF
--- a/workflows/social/Extensions/ControlPanel.bonsai
+++ b/workflows/social/Extensions/ControlPanel.bonsai
@@ -136,18 +136,6 @@
               <Combinator xsi:type="dsp:SelectChannels">
                 <dsp:Channels>
                   <dsp:int>0</dsp:int>
-                  <dsp:int>3</dsp:int>
-                </dsp:Channels>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="VisualizerMapping" />
-            <Expression xsi:type="SubscribeSubject">
-              <Name>PatchState</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="dsp:SelectChannels">
-                <dsp:Channels>
-                  <dsp:int>1</dsp:int>
                   <dsp:int>4</dsp:int>
                 </dsp:Channels>
               </Combinator>
@@ -159,8 +147,20 @@
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="dsp:SelectChannels">
                 <dsp:Channels>
-                  <dsp:int>2</dsp:int>
+                  <dsp:int>1</dsp:int>
                   <dsp:int>5</dsp:int>
+                </dsp:Channels>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="VisualizerMapping" />
+            <Expression xsi:type="SubscribeSubject">
+              <Name>PatchState</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="dsp:SelectChannels">
+                <dsp:Channels>
+                  <dsp:int>2</dsp:int>
+                  <dsp:int>6</dsp:int>
                 </dsp:Channels>
               </Combinator>
             </Expression>
@@ -276,32 +276,6 @@
               </viz:CellSpans>
             </Expression>
             <Expression xsi:type="VisualizerMapping" />
-            <Expression xsi:type="aeon-env:ExperimentProperties">
-              <aeon-env:HelpVisible>false</aeon-env:HelpVisible>
-              <aeon-env:ToolbarVisible>false</aeon-env:ToolbarVisible>
-            </Expression>
-            <Expression xsi:type="VisualizerMapping" />
-            <Expression xsi:type="SubscribeSubject">
-              <Name>VideoEvents</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="aeon-env:ButtonSource">
-                <aeon-env:Text>Reload Environment</aeon-env:Text>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>ReloadEnvironment</Name>
-            </Expression>
-            <Expression xsi:type="VisualizerMapping" />
-            <Expression xsi:type="viz:TableLayoutPanelBuilder">
-              <viz:Name>PatchStatistics</viz:Name>
-              <viz:ColumnCount>1</viz:ColumnCount>
-              <viz:RowCount>2</viz:RowCount>
-              <viz:ColumnStyles />
-              <viz:RowStyles />
-              <viz:CellSpans />
-            </Expression>
-            <Expression xsi:type="VisualizerMapping" />
             <Expression xsi:type="SubscribeSubject">
               <Name>RfidMeasurements</Name>
             </Expression>
@@ -323,6 +297,18 @@
                   <Edge From="0" To="1" Label="Source1" />
                 </Edges>
               </Workflow>
+            </Expression>
+            <Expression xsi:type="VisualizerMapping" />
+            <Expression xsi:type="SubscribeSubject">
+              <Name>PatchState</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="dsp:SelectChannels">
+                <dsp:Channels>
+                  <dsp:int>3</dsp:int>
+                  <dsp:int>7</dsp:int>
+                </dsp:Channels>
+              </Combinator>
             </Expression>
             <Expression xsi:type="VisualizerMapping" />
             <Expression xsi:type="SubscribeSubject">
@@ -448,30 +434,25 @@
             <Edge From="37" To="38" Label="Source1" />
             <Edge From="38" To="39" Label="Source12" />
             <Edge From="39" To="40" Label="Source1" />
-            <Edge From="40" To="63" Label="Source1" />
+            <Edge From="40" To="58" Label="Source1" />
             <Edge From="41" To="42" Label="Source1" />
-            <Edge From="42" To="47" Label="Source1" />
+            <Edge From="42" To="43" Label="Source1" />
             <Edge From="43" To="44" Label="Source1" />
-            <Edge From="44" To="45" Label="Source1" />
+            <Edge From="44" To="56" Label="Source1" />
             <Edge From="45" To="46" Label="Source1" />
-            <Edge From="46" To="47" Label="Source2" />
-            <Edge From="47" To="48" Label="Source1" />
-            <Edge From="48" To="61" Label="Source1" />
+            <Edge From="46" To="47" Label="Source1" />
+            <Edge From="47" To="56" Label="Source2" />
+            <Edge From="48" To="49" Label="Source1" />
             <Edge From="49" To="50" Label="Source1" />
             <Edge From="50" To="51" Label="Source1" />
-            <Edge From="51" To="52" Label="Source1" />
-            <Edge From="52" To="61" Label="Source2" />
+            <Edge From="51" To="56" Label="Source3" />
+            <Edge From="52" To="53" Label="Source1" />
             <Edge From="53" To="54" Label="Source1" />
             <Edge From="54" To="55" Label="Source1" />
-            <Edge From="55" To="56" Label="Source1" />
-            <Edge From="56" To="61" Label="Source3" />
-            <Edge From="57" To="58" Label="Source1" />
+            <Edge From="55" To="56" Label="Source4" />
+            <Edge From="56" To="57" Label="Source1" />
+            <Edge From="57" To="58" Label="Source2" />
             <Edge From="58" To="59" Label="Source1" />
-            <Edge From="59" To="60" Label="Source1" />
-            <Edge From="60" To="61" Label="Source4" />
-            <Edge From="61" To="62" Label="Source1" />
-            <Edge From="62" To="63" Label="Source2" />
-            <Edge From="63" To="64" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
@@ -479,8 +460,30 @@
         <Name>SubjectActivity</Name>
         <Workflow>
           <Nodes>
+            <Expression xsi:type="aeon-env:ExperimentProperties">
+              <aeon-env:HelpVisible>false</aeon-env:HelpVisible>
+              <aeon-env:ToolbarVisible>false</aeon-env:ToolbarVisible>
+            </Expression>
+            <Expression xsi:type="VisualizerMapping" />
             <Expression xsi:type="SubscribeSubject">
-              <Name>Heatmap</Name>
+              <Name>VideoEvents</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="aeon-env:ButtonSource">
+                <aeon-env:Text>Reload Environment</aeon-env:Text>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>ReloadEnvironment</Name>
+            </Expression>
+            <Expression xsi:type="VisualizerMapping" />
+            <Expression xsi:type="viz:TableLayoutPanelBuilder">
+              <viz:Name>Environment</viz:Name>
+              <viz:ColumnCount>1</viz:ColumnCount>
+              <viz:RowCount>2</viz:RowCount>
+              <viz:ColumnStyles />
+              <viz:RowStyles />
+              <viz:CellSpans />
             </Expression>
             <Expression xsi:type="VisualizerMapping" />
             <Expression xsi:type="SubscribeSubject">
@@ -521,18 +524,24 @@
           </Nodes>
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
-            <Edge From="1" To="12" Label="Source1" />
+            <Edge From="1" To="6" Label="Source1" />
             <Edge From="2" To="3" Label="Source1" />
-            <Edge From="3" To="7" Label="Source1" />
+            <Edge From="3" To="4" Label="Source1" />
             <Edge From="4" To="5" Label="Source1" />
-            <Edge From="5" To="6" Label="Source1" />
-            <Edge From="6" To="7" Label="Source2" />
-            <Edge From="7" To="8" Label="Source1" />
+            <Edge From="5" To="6" Label="Source2" />
+            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="7" To="18" Label="Source1" />
             <Edge From="8" To="9" Label="Source1" />
-            <Edge From="9" To="12" Label="Source2" />
+            <Edge From="9" To="13" Label="Source1" />
             <Edge From="10" To="11" Label="Source1" />
-            <Edge From="11" To="12" Label="Source3" />
-            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="11" To="12" Label="Source1" />
+            <Edge From="12" To="13" Label="Source2" />
+            <Edge From="13" To="14" Label="Source1" />
+            <Edge From="14" To="15" Label="Source1" />
+            <Edge From="15" To="18" Label="Source2" />
+            <Edge From="16" To="17" Label="Source1" />
+            <Edge From="17" To="18" Label="Source3" />
+            <Edge From="18" To="19" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
@@ -1190,6 +1199,9 @@ FilteredWeight.Value - BaselinedWeight.Value as Baseline)</scr:Expression>
             <Expression xsi:type="MemberSelector">
               <Selector>Value.Image</Selector>
             </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>Heatmap</Name>
+            </Expression>
             <Expression xsi:type="ExternalizedMapping">
               <Property Name="SelectedStream" />
             </Expression>
@@ -1206,6 +1218,7 @@ FilteredWeight.Value - BaselinedWeight.Value as Baseline)</scr:Expression>
                   <p1:string>CameraPatch1</p1:string>
                   <p1:string>CameraPatch2</p1:string>
                   <p1:string>CameraPatch3</p1:string>
+                  <p1:string>HeatMap</p1:string>
                 </p1:StreamNames>
               </Combinator>
             </Expression>
@@ -1213,25 +1226,26 @@ FilteredWeight.Value - BaselinedWeight.Value as Baseline)</scr:Expression>
           </Nodes>
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
-            <Edge From="1" To="19" Label="Source1" />
+            <Edge From="1" To="20" Label="Source1" />
             <Edge From="2" To="3" Label="Source1" />
-            <Edge From="3" To="19" Label="Source2" />
+            <Edge From="3" To="20" Label="Source2" />
             <Edge From="4" To="5" Label="Source1" />
-            <Edge From="5" To="19" Label="Source3" />
+            <Edge From="5" To="20" Label="Source3" />
             <Edge From="6" To="7" Label="Source1" />
-            <Edge From="7" To="19" Label="Source4" />
+            <Edge From="7" To="20" Label="Source4" />
             <Edge From="8" To="9" Label="Source1" />
-            <Edge From="9" To="19" Label="Source5" />
+            <Edge From="9" To="20" Label="Source5" />
             <Edge From="10" To="11" Label="Source1" />
-            <Edge From="11" To="19" Label="Source6" />
+            <Edge From="11" To="20" Label="Source6" />
             <Edge From="12" To="13" Label="Source1" />
-            <Edge From="13" To="19" Label="Source7" />
+            <Edge From="13" To="20" Label="Source7" />
             <Edge From="14" To="15" Label="Source1" />
-            <Edge From="15" To="19" Label="Source8" />
+            <Edge From="15" To="20" Label="Source8" />
             <Edge From="16" To="17" Label="Source1" />
-            <Edge From="17" To="19" Label="Source9" />
-            <Edge From="18" To="19" Label="Source10" />
-            <Edge From="19" To="20" Label="Source1" />
+            <Edge From="17" To="20" Label="Source9" />
+            <Edge From="18" To="20" Label="Source10" />
+            <Edge From="19" To="20" Label="Source11" />
+            <Edge From="20" To="21" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/workflows/social/Extensions/EnvironmentLogic.bonsai
+++ b/workflows/social/Extensions/EnvironmentLogic.bonsai
@@ -743,6 +743,29 @@ RatePatch3 as Rate)</scr:Expression>
             <Expression xsi:type="MulticastSubject">
               <Name>Patch3ThresholdCrossing</Name>
             </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>PatchDummy1WheelDisplacement</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value</Selector>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="DistanceThreshold" DisplayName="ThresholdPatchDummy1" />
+              <Property Name="Rate" DisplayName="RatePatchDummy1" />
+            </Expression>
+            <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RandomDepletion.bonsai">
+              <Name>PatchDummy1DistanceState</Name>
+              <DistanceThreshold>75</DistanceThreshold>
+              <Rate>0.01</Rate>
+              <DeliveryCount>PatchDummy1DeliveryCount</DeliveryCount>
+              <PatchState>PatchDummy1State</PatchState>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>PatchDummy1DeliverPellet</Name>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>PatchDummy1ThresholdCrossing</Name>
+            </Expression>
           </Nodes>
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
@@ -760,6 +783,11 @@ RatePatch3 as Rate)</scr:Expression>
             <Edge From="14" To="15" Label="Source2" />
             <Edge From="15" To="16" Label="Source1" />
             <Edge From="16" To="17" Label="Source1" />
+            <Edge From="18" To="19" Label="Source1" />
+            <Edge From="19" To="21" Label="Source1" />
+            <Edge From="20" To="21" Label="Source2" />
+            <Edge From="21" To="22" Label="Source1" />
+            <Edge From="22" To="23" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
@@ -783,6 +811,9 @@ RatePatch3 as Rate)</scr:Expression>
       </Expression>
       <Expression xsi:type="rx:PublishSubject" TypeArguments="sys:Int32">
         <rx:Name>Patch3ThresholdCrossing</rx:Name>
+      </Expression>
+      <Expression xsi:type="rx:PublishSubject" TypeArguments="sys:Int32">
+        <rx:Name>PatchDummy1ThresholdCrossing</rx:Name>
       </Expression>
       <Expression xsi:type="GroupWorkflow">
         <Name>UpdatePelletCount</Name>

--- a/workflows/social/Extensions/Visualization.bonsai
+++ b/workflows/social/Extensions/Visualization.bonsai
@@ -78,6 +78,9 @@
         <Name>Patch3DistanceState</Name>
       </Expression>
       <Expression xsi:type="SubscribeSubject">
+        <Name>PatchDummy1DistanceState</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
         <Name>Patch1State</Name>
       </Expression>
       <Expression xsi:type="MemberSelector">
@@ -91,6 +94,12 @@
       </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>Patch3State</Name>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Item1</Selector>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>PatchDummy1State</Name>
       </Expression>
       <Expression xsi:type="MemberSelector">
         <Selector>Item1</Selector>
@@ -1340,136 +1349,137 @@ Value.TagId as TagId,
       <Edge From="10" To="11" Label="Source1" />
       <Edge From="11" To="12" Label="Source1" />
       <Edge From="12" To="13" Label="Source1" />
-      <Edge From="14" To="23" Label="Source1" />
-      <Edge From="14" To="24" Label="Source2" />
-      <Edge From="15" To="23" Label="Source2" />
-      <Edge From="16" To="23" Label="Source3" />
-      <Edge From="17" To="18" Label="Source1" />
-      <Edge From="18" To="23" Label="Source4" />
-      <Edge From="19" To="20" Label="Source1" />
-      <Edge From="20" To="23" Label="Source5" />
-      <Edge From="21" To="22" Label="Source1" />
-      <Edge From="22" To="23" Label="Source6" />
-      <Edge From="23" To="24" Label="Source1" />
+      <Edge From="14" To="26" Label="Source1" />
+      <Edge From="14" To="27" Label="Source2" />
+      <Edge From="15" To="26" Label="Source2" />
+      <Edge From="16" To="26" Label="Source3" />
+      <Edge From="17" To="26" Label="Source4" />
+      <Edge From="18" To="19" Label="Source1" />
+      <Edge From="19" To="26" Label="Source5" />
+      <Edge From="20" To="21" Label="Source1" />
+      <Edge From="21" To="26" Label="Source6" />
+      <Edge From="22" To="23" Label="Source1" />
+      <Edge From="23" To="26" Label="Source7" />
       <Edge From="24" To="25" Label="Source1" />
-      <Edge From="25" To="26" Label="Source1" />
+      <Edge From="25" To="26" Label="Source8" />
+      <Edge From="26" To="27" Label="Source1" />
       <Edge From="27" To="28" Label="Source1" />
-      <Edge From="28" To="30" Label="Source1" />
-      <Edge From="29" To="30" Label="Source2" />
+      <Edge From="28" To="29" Label="Source1" />
       <Edge From="30" To="31" Label="Source1" />
-      <Edge From="31" To="32" Label="Source1" />
+      <Edge From="31" To="33" Label="Source1" />
+      <Edge From="32" To="33" Label="Source2" />
       <Edge From="33" To="34" Label="Source1" />
-      <Edge From="34" To="36" Label="Source1" />
-      <Edge From="35" To="36" Label="Source2" />
+      <Edge From="34" To="35" Label="Source1" />
       <Edge From="36" To="37" Label="Source1" />
-      <Edge From="37" To="38" Label="Source1" />
+      <Edge From="37" To="39" Label="Source1" />
+      <Edge From="38" To="39" Label="Source2" />
       <Edge From="39" To="40" Label="Source1" />
-      <Edge From="40" To="42" Label="Source1" />
-      <Edge From="41" To="42" Label="Source2" />
+      <Edge From="40" To="41" Label="Source1" />
       <Edge From="42" To="43" Label="Source1" />
-      <Edge From="43" To="44" Label="Source1" />
+      <Edge From="43" To="45" Label="Source1" />
+      <Edge From="44" To="45" Label="Source2" />
       <Edge From="45" To="46" Label="Source1" />
       <Edge From="46" To="47" Label="Source1" />
-      <Edge From="47" To="48" Label="Source1" />
+      <Edge From="48" To="49" Label="Source1" />
       <Edge From="49" To="50" Label="Source1" />
       <Edge From="50" To="51" Label="Source1" />
-      <Edge From="51" To="52" Label="Source1" />
+      <Edge From="52" To="53" Label="Source1" />
       <Edge From="53" To="54" Label="Source1" />
       <Edge From="54" To="55" Label="Source1" />
-      <Edge From="55" To="56" Label="Source1" />
-      <Edge From="57" To="60" Label="Source1" />
-      <Edge From="58" To="60" Label="Source2" />
-      <Edge From="59" To="60" Label="Source3" />
-      <Edge From="60" To="61" Label="Source1" />
-      <Edge From="61" To="62" Label="Source1" />
-      <Edge From="62" To="63" Label="Source1" />
-      <Edge From="64" To="67" Label="Source1" />
-      <Edge From="65" To="67" Label="Source2" />
-      <Edge From="66" To="67" Label="Source3" />
-      <Edge From="67" To="68" Label="Source1" />
-      <Edge From="68" To="69" Label="Source1" />
-      <Edge From="69" To="70" Label="Source1" />
+      <Edge From="56" To="57" Label="Source1" />
+      <Edge From="57" To="58" Label="Source1" />
+      <Edge From="58" To="59" Label="Source1" />
+      <Edge From="60" To="63" Label="Source1" />
+      <Edge From="61" To="63" Label="Source2" />
+      <Edge From="62" To="63" Label="Source3" />
+      <Edge From="63" To="64" Label="Source1" />
+      <Edge From="64" To="65" Label="Source1" />
+      <Edge From="65" To="66" Label="Source1" />
+      <Edge From="67" To="70" Label="Source1" />
+      <Edge From="68" To="70" Label="Source2" />
+      <Edge From="69" To="70" Label="Source3" />
+      <Edge From="70" To="71" Label="Source1" />
       <Edge From="71" To="72" Label="Source1" />
       <Edge From="72" To="73" Label="Source1" />
-      <Edge From="73" To="80" Label="Source1" />
       <Edge From="74" To="75" Label="Source1" />
       <Edge From="75" To="76" Label="Source1" />
-      <Edge From="76" To="80" Label="Source2" />
+      <Edge From="76" To="83" Label="Source1" />
       <Edge From="77" To="78" Label="Source1" />
       <Edge From="78" To="79" Label="Source1" />
-      <Edge From="79" To="80" Label="Source3" />
+      <Edge From="79" To="83" Label="Source2" />
       <Edge From="80" To="81" Label="Source1" />
       <Edge From="81" To="82" Label="Source1" />
-      <Edge From="82" To="83" Label="Source1" />
+      <Edge From="82" To="83" Label="Source3" />
       <Edge From="83" To="84" Label="Source1" />
+      <Edge From="84" To="85" Label="Source1" />
       <Edge From="85" To="86" Label="Source1" />
       <Edge From="86" To="87" Label="Source1" />
       <Edge From="88" To="89" Label="Source1" />
       <Edge From="89" To="90" Label="Source1" />
-      <Edge From="90" To="91" Label="Source1" />
       <Edge From="91" To="92" Label="Source1" />
+      <Edge From="92" To="93" Label="Source1" />
       <Edge From="93" To="94" Label="Source1" />
       <Edge From="94" To="95" Label="Source1" />
       <Edge From="96" To="97" Label="Source1" />
       <Edge From="97" To="98" Label="Source1" />
-      <Edge From="98" To="99" Label="Source1" />
       <Edge From="99" To="100" Label="Source1" />
+      <Edge From="100" To="101" Label="Source1" />
       <Edge From="101" To="102" Label="Source1" />
       <Edge From="102" To="103" Label="Source1" />
       <Edge From="104" To="105" Label="Source1" />
       <Edge From="105" To="106" Label="Source1" />
-      <Edge From="106" To="107" Label="Source1" />
       <Edge From="107" To="108" Label="Source1" />
+      <Edge From="108" To="109" Label="Source1" />
       <Edge From="109" To="110" Label="Source1" />
-      <Edge From="111" To="112" Label="Source1" />
+      <Edge From="110" To="111" Label="Source1" />
       <Edge From="112" To="113" Label="Source1" />
-      <Edge From="113" To="114" Label="Source1" />
-      <Edge From="114" To="117" Label="Source1" />
+      <Edge From="114" To="115" Label="Source1" />
       <Edge From="115" To="116" Label="Source1" />
-      <Edge From="116" To="117" Label="Source2" />
-      <Edge From="117" To="118" Label="Source1" />
+      <Edge From="116" To="117" Label="Source1" />
+      <Edge From="117" To="120" Label="Source1" />
       <Edge From="118" To="119" Label="Source1" />
+      <Edge From="119" To="120" Label="Source2" />
       <Edge From="120" To="121" Label="Source1" />
       <Edge From="121" To="122" Label="Source1" />
-      <Edge From="122" To="123" Label="Source1" />
       <Edge From="123" To="124" Label="Source1" />
-      <Edge From="125" To="128" Label="Source1" />
-      <Edge From="125" To="129" Label="Source2" />
-      <Edge From="126" To="128" Label="Source2" />
-      <Edge From="127" To="128" Label="Source3" />
-      <Edge From="128" To="129" Label="Source1" />
-      <Edge From="129" To="130" Label="Source1" />
-      <Edge From="130" To="131" Label="Source1" />
+      <Edge From="124" To="125" Label="Source1" />
+      <Edge From="125" To="126" Label="Source1" />
+      <Edge From="126" To="127" Label="Source1" />
+      <Edge From="128" To="131" Label="Source1" />
+      <Edge From="128" To="132" Label="Source2" />
+      <Edge From="129" To="131" Label="Source2" />
+      <Edge From="130" To="131" Label="Source3" />
       <Edge From="131" To="132" Label="Source1" />
-      <Edge From="133" To="135" Label="Source1" />
-      <Edge From="134" To="135" Label="Source2" />
-      <Edge From="135" To="139" Label="Source1" />
-      <Edge From="136" To="137" Label="Source1" />
-      <Edge From="137" To="138" Label="Source1" />
-      <Edge From="138" To="139" Label="Source2" />
+      <Edge From="132" To="133" Label="Source1" />
+      <Edge From="133" To="134" Label="Source1" />
+      <Edge From="134" To="135" Label="Source1" />
+      <Edge From="136" To="138" Label="Source1" />
+      <Edge From="137" To="138" Label="Source2" />
+      <Edge From="138" To="142" Label="Source1" />
       <Edge From="139" To="140" Label="Source1" />
       <Edge From="140" To="141" Label="Source1" />
+      <Edge From="141" To="142" Label="Source2" />
       <Edge From="142" To="143" Label="Source1" />
-      <Edge From="143" To="146" Label="Source1" />
-      <Edge From="144" To="145" Label="Source1" />
-      <Edge From="145" To="146" Label="Source2" />
-      <Edge From="146" To="147" Label="Source1" />
+      <Edge From="143" To="144" Label="Source1" />
+      <Edge From="145" To="146" Label="Source1" />
+      <Edge From="146" To="149" Label="Source1" />
       <Edge From="147" To="148" Label="Source1" />
-      <Edge From="148" To="151" Label="Source1" />
+      <Edge From="148" To="149" Label="Source2" />
       <Edge From="149" To="150" Label="Source1" />
-      <Edge From="150" To="151" Label="Source2" />
-      <Edge From="151" To="152" Label="Source1" />
+      <Edge From="150" To="151" Label="Source1" />
+      <Edge From="151" To="154" Label="Source1" />
       <Edge From="152" To="153" Label="Source1" />
-      <Edge From="153" To="154" Label="Source1" />
-      <Edge From="155" To="158" Label="Source1" />
+      <Edge From="153" To="154" Label="Source2" />
+      <Edge From="154" To="155" Label="Source1" />
+      <Edge From="155" To="156" Label="Source1" />
       <Edge From="156" To="157" Label="Source1" />
-      <Edge From="157" To="158" Label="Source2" />
-      <Edge From="158" To="159" Label="Source1" />
+      <Edge From="158" To="161" Label="Source1" />
       <Edge From="159" To="160" Label="Source1" />
+      <Edge From="160" To="161" Label="Source2" />
       <Edge From="161" To="162" Label="Source1" />
-      <Edge From="163" To="164" Label="Source1" />
-      <Edge From="165" To="166" Label="Source1" />
-      <Edge From="167" To="168" Label="Source1" />
+      <Edge From="162" To="163" Label="Source1" />
+      <Edge From="164" To="165" Label="Source1" />
+      <Edge From="166" To="167" Label="Source1" />
       <Edge From="168" To="169" Label="Source1" />
       <Edge From="170" To="171" Label="Source1" />
       <Edge From="171" To="172" Label="Source1" />
@@ -1482,19 +1492,21 @@ Value.TagId as TagId,
       <Edge From="182" To="183" Label="Source1" />
       <Edge From="183" To="184" Label="Source1" />
       <Edge From="185" To="186" Label="Source1" />
-      <Edge From="186" To="197" Label="Source1" />
-      <Edge From="187" To="188" Label="Source1" />
-      <Edge From="188" To="197" Label="Source2" />
-      <Edge From="189" To="190" Label="Source1" />
-      <Edge From="190" To="197" Label="Source3" />
-      <Edge From="191" To="192" Label="Source1" />
-      <Edge From="192" To="197" Label="Source4" />
-      <Edge From="193" To="194" Label="Source1" />
-      <Edge From="194" To="197" Label="Source5" />
-      <Edge From="195" To="196" Label="Source1" />
-      <Edge From="196" To="197" Label="Source6" />
-      <Edge From="197" To="198" Label="Source1" />
+      <Edge From="186" To="187" Label="Source1" />
+      <Edge From="188" To="189" Label="Source1" />
+      <Edge From="189" To="200" Label="Source1" />
+      <Edge From="190" To="191" Label="Source1" />
+      <Edge From="191" To="200" Label="Source2" />
+      <Edge From="192" To="193" Label="Source1" />
+      <Edge From="193" To="200" Label="Source3" />
+      <Edge From="194" To="195" Label="Source1" />
+      <Edge From="195" To="200" Label="Source4" />
+      <Edge From="196" To="197" Label="Source1" />
+      <Edge From="197" To="200" Label="Source5" />
       <Edge From="198" To="199" Label="Source1" />
+      <Edge From="199" To="200" Label="Source6" />
+      <Edge From="200" To="201" Label="Source1" />
+      <Edge From="201" To="202" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
This PR changes the table layout panel according to the requirements specified in #540 
There was the need to create the PatchDummy1DistanceState and PatchDummy1ThresholdCrossing  and PatchDummy1DeliverPellet subjects.

Fixes #540