### PR TITLE
Fix timestamp errors and repetitions in Environment_SubjectVisits.csv

### DIFF
--- a/workflows/social/Extensions/FormatRegionVisits.bonsai
+++ b/workflows/social/Extensions/FormatRegionVisits.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.7.1"
+<WorkflowBuilder Version="2.8.1"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
@@ -7,17 +7,6 @@
   <Description>Formats region entry and exit events for the event log.</Description>
   <Workflow>
     <Nodes>
-      <Expression xsi:type="SubscribeSubject">
-        <Name>SubjectState</Name>
-      </Expression>
-      <Expression xsi:type="ExternalizedMapping">
-        <Property Name="Value" DisplayName="Name" Description="The name of the visited region." />
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="StringProperty">
-          <Value />
-        </Combinator>
-      </Expression>
       <Expression xsi:type="WorkflowInput">
         <Name>Source1</Name>
       </Expression>
@@ -29,27 +18,42 @@
           <rx:Count>1</rx:Count>
         </Combinator>
       </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>SubjectState</Name>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="Name" Description="The name of the visited region." />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="StringProperty">
+          <Value />
+        </Combinator>
+      </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:CombineLatest" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:WithLatestFrom" />
       </Expression>
       <Expression xsi:type="scr:ExpressionTransform">
         <scr:Expression>new(
 Item1.Seconds as Seconds,
-new(Item2.Value.Id as Id,
+new(Item2.Item1.Value.Id as Id,
     Item1.Value ? "Enter" : "Exit" as Event,
-    Item3 as Value) as Value)</scr:Expression>
+    Item2.Item2 as Value) as Value)</scr:Expression>
       </Expression>
       <Expression xsi:type="WorkflowOutput" />
     </Nodes>
     <Edges>
-      <Edge From="0" To="6" Label="Source2" />
+      <Edge From="0" To="1" Label="Source1" />
       <Edge From="1" To="2" Label="Source1" />
-      <Edge From="2" To="6" Label="Source3" />
-      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="2" To="7" Label="Source1" />
+      <Edge From="3" To="6" Label="Source1" />
       <Edge From="4" To="5" Label="Source1" />
-      <Edge From="5" To="6" Label="Source1" />
-      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="5" To="6" Label="Source2" />
+      <Edge From="6" To="7" Label="Source2" />
       <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
Refactored FormatRegionVisits.bonsai
There was a CombineLatest with the SubjectState inside this workflow that was resending the old event of a visit when subject state changes.
This sometimes implies that the logger tries to log into a file that was previously created and closed causing the application to crash.
Add a WithLatestFrom prepended by the CombineLatest and that fixed the issue.


Fixes #514 