### PR TITLE
Add new RFID events to raster visualizer

### DIFF
--- a/workflows/social/Extensions/ControlPanel.bonsai
+++ b/workflows/social/Extensions/ControlPanel.bonsai
@@ -810,11 +810,6 @@ P3 (rate: {8}, d0: {7}, thr: {6:0.##})</Format>
             <Expression xsi:type="SubscribeSubject">
               <Name>Patch1Controller</Name>
             </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Skip">
-                <rx:Count>1</rx:Count>
-              </Combinator>
-            </Expression>
             <Expression xsi:type="rx:Condition">
               <Name>Reset</Name>
               <Workflow>
@@ -876,11 +871,6 @@ P3 (rate: {8}, d0: {7}, thr: {6:0.##})</Format>
             <Expression xsi:type="SubscribeSubject">
               <Name>Patch2Controller</Name>
             </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Skip">
-                <rx:Count>1</rx:Count>
-              </Combinator>
-            </Expression>
             <Expression xsi:type="rx:Condition">
               <Name>Reset</Name>
               <Workflow>
@@ -941,11 +931,6 @@ P3 (rate: {8}, d0: {7}, thr: {6:0.##})</Format>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>Patch3Controller</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Skip">
-                <rx:Count>1</rx:Count>
-              </Combinator>
             </Expression>
             <Expression xsi:type="rx:Condition">
               <Name>Reset</Name>
@@ -1054,23 +1039,20 @@ P3 (rate: {8}, d0: {7}, thr: {6:0.##})</Format>
             <Edge From="45" To="46" Label="Source1" />
             <Edge From="46" To="47" Label="Source1" />
             <Edge From="48" To="49" Label="Source1" />
+            <Edge From="48" To="51" Label="Source1" />
             <Edge From="49" To="50" Label="Source1" />
-            <Edge From="49" To="52" Label="Source1" />
-            <Edge From="50" To="51" Label="Source1" />
+            <Edge From="51" To="52" Label="Source1" />
             <Edge From="52" To="53" Label="Source1" />
-            <Edge From="53" To="54" Label="Source1" />
+            <Edge From="54" To="55" Label="Source1" />
+            <Edge From="54" To="57" Label="Source1" />
             <Edge From="55" To="56" Label="Source1" />
-            <Edge From="56" To="57" Label="Source1" />
-            <Edge From="56" To="59" Label="Source1" />
             <Edge From="57" To="58" Label="Source1" />
-            <Edge From="59" To="60" Label="Source1" />
+            <Edge From="58" To="59" Label="Source1" />
             <Edge From="60" To="61" Label="Source1" />
-            <Edge From="62" To="63" Label="Source1" />
+            <Edge From="60" To="63" Label="Source1" />
+            <Edge From="61" To="62" Label="Source1" />
             <Edge From="63" To="64" Label="Source1" />
-            <Edge From="63" To="66" Label="Source1" />
             <Edge From="64" To="65" Label="Source1" />
-            <Edge From="66" To="67" Label="Source1" />
-            <Edge From="67" To="68" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/workflows/social/Extensions/Visualization.bonsai
+++ b/workflows/social/Extensions/Visualization.bonsai
@@ -1271,6 +1271,28 @@ Value.TagId as TagId,
 0 as Index)</scr:Expression>
       </Expression>
       <Expression xsi:type="SubscribeSubject">
+        <Name>GateEastRfidInboundDetected</Name>
+      </Expression>
+      <Expression xsi:type="scr:ExpressionTransform">
+        <scr:Expression>new(
+Seconds as Seconds,
+Value.Location as Location,
+Value.TagId as TagId,
+"GateEast" as Name,
+1 as Index)</scr:Expression>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>GateWestRfidInboundDetected</Name>
+      </Expression>
+      <Expression xsi:type="scr:ExpressionTransform">
+        <scr:Expression>new(
+Seconds as Seconds,
+Value.Location as Location,
+Value.TagId as TagId,
+"GateWest" as Name,
+2 as Index)</scr:Expression>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
         <Name>NestRfid1InboundDetected</Name>
       </Expression>
       <Expression xsi:type="scr:ExpressionTransform">
@@ -1279,7 +1301,7 @@ Seconds as Seconds,
 Value.Location as Location,
 Value.TagId as TagId,
 "NestRfid1" as Name,
-1 as Index)</scr:Expression>
+3 as Index)</scr:Expression>
       </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>NestRfid2InboundDetected</Name>
@@ -1290,7 +1312,7 @@ Seconds as Seconds,
 Value.Location as Location,
 Value.TagId as TagId,
 "NestRfid2" as Name,
-2 as Index)</scr:Expression>
+4 as Index)</scr:Expression>
       </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>Patch1RfidInboundDetected</Name>
@@ -1301,7 +1323,7 @@ Seconds as Seconds,
 Value.Location as Location,
 Value.TagId as TagId,
 "Patch1" as Name,
-3 as Index)</scr:Expression>
+5 as Index)</scr:Expression>
       </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>Patch2RfidInboundDetected</Name>
@@ -1312,7 +1334,7 @@ Seconds as Seconds,
 Value.Location as Location,
 Value.TagId as TagId,
 "Patch2" as Name,
-4 as Index)</scr:Expression>
+6 as Index)</scr:Expression>
       </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>Patch3RfidInboundDetected</Name>
@@ -1323,7 +1345,18 @@ Seconds as Seconds,
 Value.Location as Location,
 Value.TagId as TagId,
 "Patch3" as Name,
-5 as Index)</scr:Expression>
+7 as Index)</scr:Expression>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>PatchDummy1RfidInboundDetected</Name>
+      </Expression>
+      <Expression xsi:type="scr:ExpressionTransform">
+        <scr:Expression>new(
+Seconds as Seconds,
+Value.Location as Location,
+Value.TagId as TagId,
+"PatchDummy1" as Name,
+8 as Index)</scr:Expression>
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:Merge" />
@@ -1494,19 +1527,25 @@ Value.TagId as TagId,
       <Edge From="185" To="186" Label="Source1" />
       <Edge From="186" To="187" Label="Source1" />
       <Edge From="188" To="189" Label="Source1" />
-      <Edge From="189" To="200" Label="Source1" />
+      <Edge From="189" To="206" Label="Source1" />
       <Edge From="190" To="191" Label="Source1" />
-      <Edge From="191" To="200" Label="Source2" />
+      <Edge From="191" To="206" Label="Source2" />
       <Edge From="192" To="193" Label="Source1" />
-      <Edge From="193" To="200" Label="Source3" />
+      <Edge From="193" To="206" Label="Source3" />
       <Edge From="194" To="195" Label="Source1" />
-      <Edge From="195" To="200" Label="Source4" />
+      <Edge From="195" To="206" Label="Source4" />
       <Edge From="196" To="197" Label="Source1" />
-      <Edge From="197" To="200" Label="Source5" />
+      <Edge From="197" To="206" Label="Source5" />
       <Edge From="198" To="199" Label="Source1" />
-      <Edge From="199" To="200" Label="Source6" />
+      <Edge From="199" To="206" Label="Source6" />
       <Edge From="200" To="201" Label="Source1" />
-      <Edge From="201" To="202" Label="Source1" />
+      <Edge From="201" To="206" Label="Source7" />
+      <Edge From="202" To="203" Label="Source1" />
+      <Edge From="203" To="206" Label="Source8" />
+      <Edge From="204" To="205" Label="Source1" />
+      <Edge From="205" To="206" Label="Source9" />
+      <Edge From="206" To="207" Label="Source1" />
+      <Edge From="207" To="208" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
New RFID reader devices have been added and logged, but were not yet included in the raster visualization. This PR assigns the two new gate RFIDs and the dummy patch with appropriate raster indices and labels.

Fixes #554 