### PR TITLE
Add pose tracking address to log name

### DIFF
--- a/workflows/social/Extensions/Logging.bonsai
+++ b/workflows/social/Extensions/Logging.bonsai
@@ -171,7 +171,7 @@
             <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogPoseTracking.bonsai">
               <Address>202</Address>
               <IdentityIndex xsi:nil="true" />
-              <LogName>CameraTop</LogName>
+              <LogName>CameraTop_202</LogName>
               <Name>PoseTrackingMetadata</Name>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />


### PR DESCRIPTION
To accommodate the custom path suffix containing model path metadata, the current implementation of the `LogPoseTracking` operator uses `LogHarp` instead of `LogHarpDemux`. This was to avoid placing the message address at the end of a long variable length string, and to give more flexibility to possible naming conventions.

There is a proposal at https://github.com/SainsburyWellcomeCentre/aeon_acquisition/pull/215 to always add the message address as an intermediate component following `LogName`, but in the interim this PR adds the address directly into the `LogName`.

Fixes #533 