### PR TITLE
Avoid double assignment of patch parameters

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2023-2024, University College London
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/bonsai/Bonsai.config
+++ b/bonsai/Bonsai.config
@@ -1,20 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Aeon.Acquisition" version="0.5.0-build240102" />
-    <Package id="Aeon.Database" version="0.1.0-build231020" />
-    <Package id="Aeon.Environment" version="0.1.0-build240102" />
-    <Package id="Aeon.Foraging" version="0.1.0-build231202" />
+    <Package id="Aeon.Acquisition" version="0.5.0" />
+    <Package id="Aeon.Database" version="0.1.0" />
+    <Package id="Aeon.Environment" version="0.1.0" />
+    <Package id="Aeon.Foraging" version="0.1.1" />
     <Package id="AsyncIO" version="0.1.69" />
-    <Package id="Bonsai" version="2.8.1" />
+    <Package id="Bonsai" version="2.8.3" />
     <Package id="Bonsai.Audio" version="2.8.0" />
-    <Package id="Bonsai.Core" version="2.8.1" />
-    <Package id="Bonsai.Design" version="2.8.0" />
+    <Package id="Bonsai.Core" version="2.8.2" />
+    <Package id="Bonsai.Design" version="2.8.1" />
     <Package id="Bonsai.Design.Visualizers" version="2.8.0" />
     <Package id="Bonsai.Dsp" version="2.8.0" />
     <Package id="Bonsai.Dsp.Design" version="2.8.0" />
-    <Package id="Bonsai.Editor" version="2.8.0" />
-    <Package id="Bonsai.Harp" version="3.5.0" />
+    <Package id="Bonsai.Editor" version="2.8.2" />
+    <Package id="Bonsai.Harp" version="3.5.2" />
     <Package id="Bonsai.Harp.Design" version="3.5.0" />
     <Package id="Bonsai.Numerics" version="0.9.0" />
     <Package id="Bonsai.Osc" version="2.7.0" />
@@ -34,7 +34,7 @@
     <Package id="Harp.Behavior" version="0.1.0" />
     <Package id="Harp.CameraControllerGen2" version="0.1.0" />
     <Package id="Harp.ClockSynchronizer" version="0.1.0" />
-    <Package id="Harp.OutputExpander" version="0.2.0-build231204" />
+    <Package id="Harp.OutputExpander" version="0.2.0" />
     <Package id="Harp.RfidReader" version="0.1.0" />
     <Package id="Harp.TimestampGeneratorGen3" version="0.1.0" />
     <Package id="jacobslusser.ScintillaNET" version="3.6.3" />
@@ -109,22 +109,22 @@
     <AssemblyReference assemblyName="Harp.TimestampGeneratorGen3" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Aeon.Acquisition" processorArchitecture="MSIL" location="Packages\Aeon.Acquisition.0.5.0-build240102\lib\net472\Aeon.Acquisition.dll" />
-    <AssemblyLocation assemblyName="Aeon.Database" processorArchitecture="MSIL" location="Packages\Aeon.Database.0.1.0-build231020\lib\net472\Aeon.Database.dll" />
-    <AssemblyLocation assemblyName="Aeon.Environment" processorArchitecture="MSIL" location="Packages\Aeon.Environment.0.1.0-build240102\lib\net472\Aeon.Environment.dll" />
-    <AssemblyLocation assemblyName="Aeon.Foraging" processorArchitecture="MSIL" location="Packages\Aeon.Foraging.0.1.0-build231202\lib\net472\Aeon.Foraging.dll" />
+    <AssemblyLocation assemblyName="Aeon.Acquisition" processorArchitecture="MSIL" location="Packages\Aeon.Acquisition.0.5.0\lib\net472\Aeon.Acquisition.dll" />
+    <AssemblyLocation assemblyName="Aeon.Database" processorArchitecture="MSIL" location="Packages\Aeon.Database.0.1.0\lib\net472\Aeon.Database.dll" />
+    <AssemblyLocation assemblyName="Aeon.Environment" processorArchitecture="MSIL" location="Packages\Aeon.Environment.0.1.0\lib\net472\Aeon.Environment.dll" />
+    <AssemblyLocation assemblyName="Aeon.Foraging" processorArchitecture="MSIL" location="Packages\Aeon.Foraging.0.1.1\lib\net472\Aeon.Foraging.dll" />
     <AssemblyLocation assemblyName="AsyncIO" processorArchitecture="MSIL" location="Packages\AsyncIO.0.1.69\lib\net40\AsyncIO.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="X86" location="Packages\Bonsai.Pylon.0.3.0\build\net462\bin\x86\Basler.Pylon.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="Amd64" location="Packages\Bonsai.Pylon.0.3.0\build\net462\bin\x64\Basler.Pylon.dll" />
-    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.1\lib\net48\Bonsai.exe" />
+    <AssemblyLocation assemblyName="Bonsai" processorArchitecture="MSIL" location="Packages\Bonsai.2.8.3\lib\net48\Bonsai.exe" />
     <AssemblyLocation assemblyName="Bonsai.Audio" processorArchitecture="MSIL" location="Packages\Bonsai.Audio.2.8.0\lib\net462\Bonsai.Audio.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.1\lib\net462\Bonsai.Core.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.0\lib\net462\Bonsai.Design.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Core" processorArchitecture="MSIL" location="Packages\Bonsai.Core.2.8.2\lib\net462\Bonsai.Core.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Design.2.8.1\lib\net462\Bonsai.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Design.Visualizers" processorArchitecture="MSIL" location="Packages\Bonsai.Design.Visualizers.2.8.0\lib\net462\Bonsai.Design.Visualizers.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.2.8.0\lib\net462\Bonsai.Dsp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Dsp.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Dsp.Design.2.8.0\lib\net462\Bonsai.Dsp.Design.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.0\lib\net472\Bonsai.Editor.dll" />
-    <AssemblyLocation assemblyName="Bonsai.Harp" processorArchitecture="MSIL" location="Packages\Bonsai.Harp.3.5.0\lib\net462\Bonsai.Harp.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Editor" processorArchitecture="MSIL" location="Packages\Bonsai.Editor.2.8.2\lib\net472\Bonsai.Editor.dll" />
+    <AssemblyLocation assemblyName="Bonsai.Harp" processorArchitecture="MSIL" location="Packages\Bonsai.Harp.3.5.2\lib\net462\Bonsai.Harp.dll" />
     <AssemblyLocation assemblyName="Bonsai.Harp.Design" processorArchitecture="MSIL" location="Packages\Bonsai.Harp.Design.3.5.0\lib\net462\Bonsai.Harp.Design.dll" />
     <AssemblyLocation assemblyName="Bonsai.Numerics" processorArchitecture="MSIL" location="Packages\Bonsai.Numerics.0.9.0\lib\net462\Bonsai.Numerics.dll" />
     <AssemblyLocation assemblyName="Bonsai.Osc" processorArchitecture="MSIL" location="Packages\Bonsai.Osc.2.7.0\lib\net462\Bonsai.Osc.dll" />
@@ -146,7 +146,7 @@
     <AssemblyLocation assemblyName="Harp.Behavior" processorArchitecture="MSIL" location="Packages\Harp.Behavior.0.1.0\lib\net462\Harp.Behavior.dll" />
     <AssemblyLocation assemblyName="Harp.CameraControllerGen2" processorArchitecture="MSIL" location="Packages\Harp.CameraControllerGen2.0.1.0\lib\net462\Harp.CameraControllerGen2.dll" />
     <AssemblyLocation assemblyName="Harp.ClockSynchronizer" processorArchitecture="MSIL" location="Packages\Harp.ClockSynchronizer.0.1.0\lib\net462\Harp.ClockSynchronizer.dll" />
-    <AssemblyLocation assemblyName="Harp.OutputExpander" processorArchitecture="MSIL" location="Packages\Harp.OutputExpander.0.2.0-build231204\lib\net462\Harp.OutputExpander.dll" />
+    <AssemblyLocation assemblyName="Harp.OutputExpander" processorArchitecture="MSIL" location="Packages\Harp.OutputExpander.0.2.0\lib\net462\Harp.OutputExpander.dll" />
     <AssemblyLocation assemblyName="Harp.RfidReader" processorArchitecture="MSIL" location="Packages\Harp.RfidReader.0.1.0\lib\net462\Harp.RfidReader.dll" />
     <AssemblyLocation assemblyName="Harp.TimestampGeneratorGen3" processorArchitecture="MSIL" location="Packages\Harp.TimestampGeneratorGen3.0.1.0\lib\net462\Harp.TimestampGeneratorGen3.dll" />
     <AssemblyLocation assemblyName="IronPython" processorArchitecture="MSIL" location="Packages\IronPython.2.7.5\lib\Net45\IronPython.dll" />

--- a/workflows/social/Extensions/EnvironmentLogic.bonsai
+++ b/workflows/social/Extensions/EnvironmentLogic.bonsai
@@ -327,6 +327,127 @@
       <Expression xsi:type="rx:PublishSubject">
         <Name>EnvironmentLoaded</Name>
       </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>PatchLogic</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>Patch1WheelDisplacement</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value</Selector>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="DistanceThreshold" DisplayName="ThresholdPatch1" />
+              <Property Name="Rate" DisplayName="RatePatch1" />
+            </Expression>
+            <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RandomDepletion.bonsai">
+              <Name>Patch1DistanceState</Name>
+              <DistanceThreshold>75</DistanceThreshold>
+              <Rate>0.01</Rate>
+              <DeliveryCount>Patch1DeliveryCount</DeliveryCount>
+              <PatchState>Patch1State</PatchState>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>Patch1DeliverPellet</Name>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>Patch1ThresholdCrossing</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>Patch2WheelDisplacement</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value</Selector>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="DistanceThreshold" DisplayName="ThresholdPatch2" />
+              <Property Name="Rate" DisplayName="RatePatch2" />
+            </Expression>
+            <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RandomDepletion.bonsai">
+              <Name>Patch2DistanceState</Name>
+              <DistanceThreshold>75</DistanceThreshold>
+              <Rate>0.01</Rate>
+              <DeliveryCount>Patch2DeliveryCount</DeliveryCount>
+              <PatchState>Patch2State</PatchState>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>Patch2DeliverPellet</Name>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>Patch2ThresholdCrossing</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>Patch3WheelDisplacement</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value</Selector>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="DistanceThreshold" DisplayName="ThresholdPatch3" />
+              <Property Name="Rate" DisplayName="RatePatch3" />
+            </Expression>
+            <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RandomDepletion.bonsai">
+              <Name>Patch3DistanceState</Name>
+              <DistanceThreshold>75</DistanceThreshold>
+              <Rate>0.01</Rate>
+              <DeliveryCount>Patch3DeliveryCount</DeliveryCount>
+              <PatchState>Patch3State</PatchState>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>Patch3DeliverPellet</Name>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>Patch3ThresholdCrossing</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>PatchDummy1WheelDisplacement</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value</Selector>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="DistanceThreshold" DisplayName="ThresholdPatchDummy1" />
+              <Property Name="Rate" DisplayName="RatePatchDummy1" />
+            </Expression>
+            <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RandomDepletion.bonsai">
+              <Name>PatchDummy1DistanceState</Name>
+              <DistanceThreshold>75</DistanceThreshold>
+              <Rate>0.01</Rate>
+              <DeliveryCount>PatchDummy1DeliveryCount</DeliveryCount>
+              <PatchState>PatchDummy1State</PatchState>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>PatchDummy1DeliverPellet</Name>
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>PatchDummy1ThresholdCrossing</Name>
+            </Expression>
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="3" Label="Source1" />
+            <Edge From="2" To="3" Label="Source2" />
+            <Edge From="3" To="4" Label="Source1" />
+            <Edge From="4" To="5" Label="Source1" />
+            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="7" To="9" Label="Source1" />
+            <Edge From="8" To="9" Label="Source2" />
+            <Edge From="9" To="10" Label="Source1" />
+            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="13" To="15" Label="Source1" />
+            <Edge From="14" To="15" Label="Source2" />
+            <Edge From="15" To="16" Label="Source1" />
+            <Edge From="16" To="17" Label="Source1" />
+            <Edge From="18" To="19" Label="Source1" />
+            <Edge From="19" To="21" Label="Source1" />
+            <Edge From="20" To="21" Label="Source2" />
+            <Edge From="21" To="22" Label="Source1" />
+            <Edge From="22" To="23" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
       <Expression xsi:type="rx:Defer">
         <Name>BlockLogic</Name>
         <Workflow>
@@ -941,137 +1062,6 @@ RatePatchDummy1 as Rate)</scr:Expression>
           </Edges>
         </Workflow>
       </Expression>
-      <Expression xsi:type="PropertyMapping">
-        <PropertyMappings>
-          <Property Name="ThresholdPatch1" Selector="ThresholdPatch1" />
-          <Property Name="RatePatch1" Selector="RatePatch1" />
-          <Property Name="ThresholdPatch2" Selector="ThresholdPatch2" />
-          <Property Name="RatePatch2" Selector="RatePatch2" />
-          <Property Name="ThresholdPatch3" Selector="ThresholdPatch3" />
-          <Property Name="RatePatch3" Selector="RatePatch3" />
-        </PropertyMappings>
-      </Expression>
-      <Expression xsi:type="GroupWorkflow">
-        <Name>PatchLogic</Name>
-        <Workflow>
-          <Nodes>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>Patch1WheelDisplacement</Name>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Value</Selector>
-            </Expression>
-            <Expression xsi:type="ExternalizedMapping">
-              <Property Name="DistanceThreshold" DisplayName="ThresholdPatch1" />
-              <Property Name="Rate" DisplayName="RatePatch1" />
-            </Expression>
-            <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RandomDepletion.bonsai">
-              <Name>Patch1DistanceState</Name>
-              <DistanceThreshold>75</DistanceThreshold>
-              <Rate>0.01</Rate>
-              <DeliveryCount>Patch1DeliveryCount</DeliveryCount>
-              <PatchState>Patch1State</PatchState>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>Patch1DeliverPellet</Name>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>Patch1ThresholdCrossing</Name>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>Patch2WheelDisplacement</Name>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Value</Selector>
-            </Expression>
-            <Expression xsi:type="ExternalizedMapping">
-              <Property Name="DistanceThreshold" DisplayName="ThresholdPatch2" />
-              <Property Name="Rate" DisplayName="RatePatch2" />
-            </Expression>
-            <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RandomDepletion.bonsai">
-              <Name>Patch2DistanceState</Name>
-              <DistanceThreshold>75</DistanceThreshold>
-              <Rate>0.01</Rate>
-              <DeliveryCount>Patch2DeliveryCount</DeliveryCount>
-              <PatchState>Patch2State</PatchState>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>Patch2DeliverPellet</Name>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>Patch2ThresholdCrossing</Name>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>Patch3WheelDisplacement</Name>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Value</Selector>
-            </Expression>
-            <Expression xsi:type="ExternalizedMapping">
-              <Property Name="DistanceThreshold" DisplayName="ThresholdPatch3" />
-              <Property Name="Rate" DisplayName="RatePatch3" />
-            </Expression>
-            <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RandomDepletion.bonsai">
-              <Name>Patch3DistanceState</Name>
-              <DistanceThreshold>75</DistanceThreshold>
-              <Rate>0.01</Rate>
-              <DeliveryCount>Patch3DeliveryCount</DeliveryCount>
-              <PatchState>Patch3State</PatchState>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>Patch3DeliverPellet</Name>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>Patch3ThresholdCrossing</Name>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>PatchDummy1WheelDisplacement</Name>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Value</Selector>
-            </Expression>
-            <Expression xsi:type="ExternalizedMapping">
-              <Property Name="DistanceThreshold" DisplayName="ThresholdPatchDummy1" />
-              <Property Name="Rate" DisplayName="RatePatchDummy1" />
-            </Expression>
-            <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:RandomDepletion.bonsai">
-              <Name>PatchDummy1DistanceState</Name>
-              <DistanceThreshold>75</DistanceThreshold>
-              <Rate>0.01</Rate>
-              <DeliveryCount>PatchDummy1DeliveryCount</DeliveryCount>
-              <PatchState>PatchDummy1State</PatchState>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>PatchDummy1DeliverPellet</Name>
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>PatchDummy1ThresholdCrossing</Name>
-            </Expression>
-          </Nodes>
-          <Edges>
-            <Edge From="0" To="1" Label="Source1" />
-            <Edge From="1" To="3" Label="Source1" />
-            <Edge From="2" To="3" Label="Source2" />
-            <Edge From="3" To="4" Label="Source1" />
-            <Edge From="4" To="5" Label="Source1" />
-            <Edge From="6" To="7" Label="Source1" />
-            <Edge From="7" To="9" Label="Source1" />
-            <Edge From="8" To="9" Label="Source2" />
-            <Edge From="9" To="10" Label="Source1" />
-            <Edge From="10" To="11" Label="Source1" />
-            <Edge From="12" To="13" Label="Source1" />
-            <Edge From="13" To="15" Label="Source1" />
-            <Edge From="14" To="15" Label="Source2" />
-            <Edge From="15" To="16" Label="Source1" />
-            <Edge From="16" To="17" Label="Source1" />
-            <Edge From="18" To="19" Label="Source1" />
-            <Edge From="19" To="21" Label="Source1" />
-            <Edge From="20" To="21" Label="Source2" />
-            <Edge From="21" To="22" Label="Source1" />
-            <Edge From="22" To="23" Label="Source1" />
-          </Edges>
-        </Workflow>
-      </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:TakeUntil" />
       </Expression>
@@ -1161,14 +1151,12 @@ RatePatchDummy1 as Rate)</scr:Expression>
       <Edge From="5" To="6" Label="Source1" />
       <Edge From="6" To="7" Label="Source1" />
       <Edge From="7" To="8" Label="Source1" />
-      <Edge From="9" To="10" Label="Source1" />
+      <Edge From="9" To="13" Label="Source1" />
       <Edge From="10" To="11" Label="Source1" />
       <Edge From="11" To="12" Label="Source1" />
-      <Edge From="11" To="14" Label="Source2" />
-      <Edge From="12" To="13" Label="Source1" />
+      <Edge From="12" To="13" Label="Source2" />
       <Edge From="13" To="14" Label="Source1" />
-      <Edge From="14" To="15" Label="Source1" />
-      <Edge From="16" To="17" Label="Source1" />
+      <Edge From="15" To="16" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
Patch state parameters are automatically updated internally at each block transition so there is no need to route the update twice into the patch logic controller properties.

This eliminates one of the redundant threshold assignments described in #497. The double `NaN` values reported on block transition are fixed via https://github.com/SainsburyWellcomeCentre/aeon_acquisition/pull/216.

Fixes #497 