### PR TITLE
New camera parameters for AEON3

### DIFF
--- a/workflows/social/Calibrate-AEON3.bonsai
+++ b/workflows/social/Calibrate-AEON3.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.1"
+<WorkflowBuilder Version="2.8.2"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
@@ -69,7 +69,7 @@
                   <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:SpinnakerVideoSource.bonsai">
                     <TriggerSource>GlobalTrigger</TriggerSource>
                     <TriggerFrequency>GlobalTriggerFrequency</TriggerFrequency>
-                    <ExposureTime>7500</ExposureTime>
+                    <ExposureTime>5000</ExposureTime>
                     <SerialNumber>23032909</SerialNumber>
                     <Gain>0</Gain>
                     <Binning>1</Binning>

--- a/workflows/social/Social-AEON3.bonsai
+++ b/workflows/social/Social-AEON3.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.1"
+<WorkflowBuilder Version="2.8.2"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Workflow>
@@ -68,7 +68,7 @@
                         <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:SpinnakerVideoSource.bonsai">
                           <TriggerSource>GlobalTrigger</TriggerSource>
                           <TriggerFrequency>GlobalTriggerFrequency</TriggerFrequency>
-                          <ExposureTime>7500</ExposureTime>
+                          <ExposureTime>5000</ExposureTime>
                           <SerialNumber>23032909</SerialNumber>
                           <Gain>0</Gain>
                           <Binning>1</Binning>
@@ -98,7 +98,7 @@
                         <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:SpinnakerVideoSource.bonsai">
                           <TriggerSource>GlobalTrigger</TriggerSource>
                           <TriggerFrequency>GlobalTriggerFrequency</TriggerFrequency>
-                          <ExposureTime>7500</ExposureTime>
+                          <ExposureTime>5000</ExposureTime>
                           <SerialNumber>23032816</SerialNumber>
                           <Gain>10</Gain>
                           <Binning>1</Binning>
@@ -128,7 +128,7 @@
                         <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:SpinnakerVideoSource.bonsai">
                           <TriggerSource>GlobalTrigger</TriggerSource>
                           <TriggerFrequency>GlobalTriggerFrequency</TriggerFrequency>
-                          <ExposureTime>7500</ExposureTime>
+                          <ExposureTime>5000</ExposureTime>
                           <SerialNumber>23032824</SerialNumber>
                           <Gain>10</Gain>
                           <Binning>1</Binning>
@@ -158,7 +158,7 @@
                         <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:SpinnakerVideoSource.bonsai">
                           <TriggerSource>GlobalTrigger</TriggerSource>
                           <TriggerFrequency>GlobalTriggerFrequency</TriggerFrequency>
-                          <ExposureTime>7500</ExposureTime>
+                          <ExposureTime>5000</ExposureTime>
                           <SerialNumber>23032825</SerialNumber>
                           <Gain>10</Gain>
                           <Binning>1</Binning>
@@ -188,7 +188,7 @@
                         <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:SpinnakerVideoSource.bonsai">
                           <TriggerSource>GlobalTrigger</TriggerSource>
                           <TriggerFrequency>GlobalTriggerFrequency</TriggerFrequency>
-                          <ExposureTime>7500</ExposureTime>
+                          <ExposureTime>5000</ExposureTime>
                           <SerialNumber>23031408</SerialNumber>
                           <Gain>10</Gain>
                           <Binning>1</Binning>
@@ -218,7 +218,7 @@
                         <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:SpinnakerVideoSource.bonsai">
                           <TriggerSource>GlobalTrigger</TriggerSource>
                           <TriggerFrequency>GlobalTriggerFrequency</TriggerFrequency>
-                          <ExposureTime>7500</ExposureTime>
+                          <ExposureTime>5000</ExposureTime>
                           <SerialNumber>23031407</SerialNumber>
                           <Gain>10</Gain>
                           <Binning>1</Binning>
@@ -248,9 +248,9 @@
                         <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:SpinnakerVideoSource.bonsai">
                           <TriggerSource>LocalTrigger</TriggerSource>
                           <TriggerFrequency>LocalTriggerFrequency</TriggerFrequency>
-                          <ExposureTime>INF</ExposureTime>
+                          <ExposureTime>3000</ExposureTime>
                           <SerialNumber>23032815</SerialNumber>
-                          <Gain>4</Gain>
+                          <Gain>10</Gain>
                           <Binning>2</Binning>
                           <FrameEvents>CameraPatch1</FrameEvents>
                         </Expression>
@@ -278,9 +278,9 @@
                         <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:SpinnakerVideoSource.bonsai">
                           <TriggerSource>LocalTrigger</TriggerSource>
                           <TriggerFrequency>LocalTriggerFrequency</TriggerFrequency>
-                          <ExposureTime>INF</ExposureTime>
+                          <ExposureTime>3000</ExposureTime>
                           <SerialNumber>23032817</SerialNumber>
-                          <Gain>4</Gain>
+                          <Gain>10</Gain>
                           <Binning>2</Binning>
                           <FrameEvents>CameraPatch2</FrameEvents>
                         </Expression>
@@ -308,9 +308,9 @@
                         <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:SpinnakerVideoSource.bonsai">
                           <TriggerSource>LocalTrigger</TriggerSource>
                           <TriggerFrequency>LocalTriggerFrequency</TriggerFrequency>
-                          <ExposureTime>INF</ExposureTime>
+                          <ExposureTime>3000</ExposureTime>
                           <SerialNumber>23032829</SerialNumber>
-                          <Gain>4</Gain>
+                          <Gain>10</Gain>
                           <Binning>2</Binning>
                           <FrameEvents>CameraPatch3</FrameEvents>
                         </Expression>
@@ -338,7 +338,7 @@
                         <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:SpinnakerVideoSource.bonsai">
                           <TriggerSource>LocalTrigger</TriggerSource>
                           <TriggerFrequency>LocalTriggerFrequency</TriggerFrequency>
-                          <ExposureTime>INF</ExposureTime>
+                          <ExposureTime>3000</ExposureTime>
                           <SerialNumber>21199218</SerialNumber>
                           <Gain>0</Gain>
                           <Binning>2</Binning>


### PR DESCRIPTION
Update camera parameters following IR lights upgrade on AEON3. 
* Exposure time reduced to reduce motion blur
* Gain increased on patch cameras to match dynamic range on AEON4

N.B. Three of the LED bars on AEON3 have some problems and are pulling more current than the others. Will need to be replaced eventually. We believe this problem came from the previous (now replaced) PSU. 

Related to #577 