### PR TITLE
Deployment of presocial phields on AEON machines 

### DIFF
--- a/workflows/presocial/Phields-Presocial-AEON3.bonsai
+++ b/workflows/presocial/Phields-Presocial-AEON3.bonsai
@@ -653,7 +653,7 @@
           <Nodes>
             <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:RepositoryLogController.bonsai">
               <RepositoryPath>..\..\</RepositoryPath>
-              <DataPath>D:\ProjectAeon</DataPath>
+              <DataPath>D:\ProjectPhieldsn</DataPath>
               <FallbackPath>D:\Tests</FallbackPath>
               <ChunkSize>1</ChunkSize>
             </Expression>

--- a/workflows/presocial/Phields-Presocial-AEON3.bonsai
+++ b/workflows/presocial/Phields-Presocial-AEON3.bonsai
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WorkflowBuilder Version="2.8.2"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
@@ -292,7 +292,7 @@
                           <TriggerSource>LocalTrigger</TriggerSource>
                           <TriggerFrequency>LocalTriggerFrequency</TriggerFrequency>
                           <ExposureTime>3000</ExposureTime>
-                          <SerialNumber>23032815</SerialNumber>
+                          <SerialNumber>23032829</SerialNumber>
                           <Gain>0</Gain>
                           <Binning>2</Binning>
                           <FrameEvents>CameraPatch2</FrameEvents>

--- a/workflows/presocial/Phields-Presocial-AEON3.bonsai
+++ b/workflows/presocial/Phields-Presocial-AEON3.bonsai
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <WorkflowBuilder Version="2.8.2"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
@@ -653,7 +653,7 @@
           <Nodes>
             <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:RepositoryLogController.bonsai">
               <RepositoryPath>..\..\</RepositoryPath>
-              <DataPath>D:\ProjectPhieldsn</DataPath>
+              <DataPath>D:\ProjectPhields</DataPath>
               <FallbackPath>D:\Tests</FallbackPath>
               <ChunkSize>1</ChunkSize>
             </Expression>
@@ -3466,7 +3466,7 @@ Item3 as Delta)</scr:Expression>
                   <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:PatchDispenser.bonsai">
                     <ControllerEvents>Patch2Controller</ControllerEvents>
                     <DispenserState>Patch2Dispenser</DispenserState>
-                    <Name>Patch12</Name>
+                    <Name>Patch2</Name>
                   </Expression>
                   <Expression xsi:type="VisualizerMapping" />
                   <Expression xsi:type="SubscribeSubject">

--- a/workflows/presocial/Phields-Presocial-AEON4.bonsai
+++ b/workflows/presocial/Phields-Presocial-AEON4.bonsai
@@ -653,7 +653,7 @@
           <Nodes>
             <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:RepositoryLogController.bonsai">
               <RepositoryPath>..\..\</RepositoryPath>
-              <DataPath>D:\ProjectAeon</DataPath>
+              <DataPath>D:\ProjectPhields</DataPath>
               <FallbackPath>D:\Tests</FallbackPath>
               <ChunkSize>1</ChunkSize>
             </Expression>

--- a/workflows/presocial/Phields-Presocial-AEON4.bonsai
+++ b/workflows/presocial/Phields-Presocial-AEON4.bonsai
@@ -292,7 +292,7 @@
                           <TriggerSource>LocalTrigger</TriggerSource>
                           <TriggerFrequency>LocalTriggerFrequency</TriggerFrequency>
                           <ExposureTime>3000</ExposureTime>
-                          <SerialNumber>23032811</SerialNumber>
+                          <SerialNumber>23032823</SerialNumber>
                           <Gain>0</Gain>
                           <Binning>2</Binning>
                           <FrameEvents>CameraPatch2</FrameEvents>

--- a/workflows/presocial/SystemStartup-AEON3.cmd
+++ b/workflows/presocial/SystemStartup-AEON3.cmd
@@ -1,2 +1,1 @@
-cd "C:\ProjectAeon\aeon_experiments\workflows\presocial0.1"
-"..\..\bonsai\Bonsai.exe" SystemStartup-AEON3.bonsai --no-editor
+powershell -ep Bypass -c "& ..\..\bonsai\Bonsai.exe SystemStartup-AEON3.bonsai --no-editor %* *>&1 | tee -a Aeon.log"

--- a/workflows/presocial/SystemStartup-AEON4.bonsai
+++ b/workflows/presocial/SystemStartup-AEON4.bonsai
@@ -50,7 +50,7 @@
                   <Expression xsi:type="ExternalizedMapping">
                     <Property Name="PortName" />
                   </Expression>
-                  <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:TimestampGenerator.bonsai">
+                  <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:ClockSynchronizer.bonsai">
                     <PortName>COM5</PortName>
                   </Expression>
                   <Expression xsi:type="WorkflowOutput" />

--- a/workflows/presocial/SystemStartup-AEON4.cmd
+++ b/workflows/presocial/SystemStartup-AEON4.cmd
@@ -1,0 +1,1 @@
+powershell -ep Bypass -c "& ..\..\bonsai\Bonsai.exe SystemStartup-AEON4.bonsai --no-editor %* *>&1 | tee -a Aeon.log"


### PR DESCRIPTION
This PR does:
- Create new logging and data paths on local computer and ceph
- Update robocopy accordingly 
- Change patch cameras to match new patch positions 
- Created system startup for AEON 3 and 4
- Tested data acquisition on both rigs 
- Tested copying to ceph
- Tested hardware components and clock synchronization